### PR TITLE
Have only a `compileOnly` dependency of the Micronaut BOM.

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -55,7 +55,6 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
                     }
                     String p = "platform"
                     annotationProcessor "$p"("io.micronaut:micronaut-bom:${micronautVersion}")
-                    implementation "$p"("io.micronaut:micronaut-bom:${micronautVersion}")
                     testAnnotationProcessor "$p"("io.micronaut:micronaut-bom:${micronautVersion}")
                     testImplementation "$p"("io.micronaut:micronaut-bom:${micronautVersion}")
                     compileOnly "$p"("io.micronaut:micronaut-bom:${micronautVersion}")


### PR DESCRIPTION
Fixes #68.

Tested locally with `micronaut-gcp-common`. Without this PR:

```xml
   1   │ <?xml version="1.0" encoding="UTF-8"?>
   2   │ <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.
       │ w3.org/2001/XMLSchema-instance">
   3   │   <!-- This module was also published with a richer model, Gradle metadata,  -->
   4   │   <!-- which should be used instead. Do not delete the following line which  -->
   5   │   <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
   6   │   <!-- that they should prefer consuming it instead. -->
   7   │   <!-- do_not_remove: published-with-gradle-metadata -->
   8   │   <modelVersion>4.0.0</modelVersion>
   9   │   <groupId>io.micronaut.gcp</groupId>
  10   │   <artifactId>micronaut-gcp-common</artifactId>
  11   │   <version>3.3.1.BUILD-SNAPSHOT</version>
  12   │   <dependencyManagement>
  13   │     <dependencies>
  14   │       <dependency>
  15   │         <groupId>io.micronaut</groupId>
  16   │         <artifactId>micronaut-bom</artifactId>
  17   │         <version>2.1.3</version>
  18   │         <type>pom</type>
  19   │         <scope>import</scope>
  20   │       </dependency>
  21   │     </dependencies>
  22   │   </dependencyManagement>
  23   │   <dependencies>
  24   │     <dependency>
  25   │       <groupId>io.micronaut</groupId>
  26   │       <artifactId>micronaut-inject</artifactId>
  27   │       <version>2.1.3</version>
  28   │       <scope>compile</scope>
  29   │     </dependency>
  30   │     <dependency>
  31   │       <groupId>com.google.auth</groupId>
  32   │       <artifactId>google-auth-library-oauth2-http</artifactId>
  33   │       <version>0.22.0</version>
  34   │       <scope>compile</scope>
  35   │     </dependency>
  36   │     <dependency>
  37   │       <groupId>com.google.cloud</groupId>
  38   │       <artifactId>google-cloud-core</artifactId>
  39   │       <version>1.94.0</version>
  40   │       <scope>compile</scope>
  41   │     </dependency>
  42   │   </dependencies>
  43   │   <name>Micronaut GCP</name>
  44   │   <description>Provides integration between Micronaut and Google Cloud Platform (GCP)</description>
  45   │   <url>http://micronaut.io</url>
  46   │   <licenses>
  47   │     <license>
  48   │       <name>The Apache Software License, Version 2.0</name>
  49   │       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
  50   │       <distribution>repo</distribution>
  51   │     </license>
  52   │   </licenses>
  53   │   <scm>
  54   │     <url>scm:git@github.com:micronaut-projects/micronaut-gcp.git</url>
  55   │     <connection>scm:git@github.com:micronaut-projects/micronaut-gcp.git</connection>
  56   │     <developerConnection>scm:git@github.com:micronaut-projects/micronaut-gcp.git</developerConnection>
  57   │   </scm>
  58   │   <developers>
  59   │     <developer>
  60   │       <id>graemerocher</id>
  61   │       <name>Graeme Rocher</name>
  62   │     </developer>
  63   │   </developers>
  64   │ </project>
```

With this PR:

```xml
   1   │ <?xml version="1.0" encoding="UTF-8"?>
   2   │ <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.
       │ w3.org/2001/XMLSchema-instance">
   3   │   <!-- This module was also published with a richer model, Gradle metadata,  -->
   4   │   <!-- which should be used instead. Do not delete the following line which  -->
   5   │   <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
   6   │   <!-- that they should prefer consuming it instead. -->
   7   │   <!-- do_not_remove: published-with-gradle-metadata -->
   8   │   <modelVersion>4.0.0</modelVersion>
   9   │   <groupId>io.micronaut.gcp</groupId>
  10   │   <artifactId>micronaut-gcp-common</artifactId>
  11   │   <version>3.3.1.BUILD-SNAPSHOT</version>
  12   │   <dependencies>
  13   │     <dependency>
  14   │       <groupId>io.micronaut</groupId>
  15   │       <artifactId>micronaut-inject</artifactId>
  16   │       <version>2.1.3</version>
  17   │       <scope>compile</scope>
  18   │     </dependency>
  19   │     <dependency>
  20   │       <groupId>com.google.auth</groupId>
  21   │       <artifactId>google-auth-library-oauth2-http</artifactId>
  22   │       <version>0.22.0</version>
  23   │       <scope>compile</scope>
  24   │     </dependency>
  25   │     <dependency>
  26   │       <groupId>com.google.cloud</groupId>
  27   │       <artifactId>google-cloud-core</artifactId>
  28   │       <version>1.94.0</version>
  29   │       <scope>compile</scope>
  30   │     </dependency>
  31   │   </dependencies>
  32   │   <name>Micronaut GCP</name>
  33   │   <description>Provides integration between Micronaut and Google Cloud Platform (GCP)</description>
  34   │   <url>http://micronaut.io</url>
  35   │   <licenses>
  36   │     <license>
  37   │       <name>The Apache Software License, Version 2.0</name>
  38   │       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
  39   │       <distribution>repo</distribution>
  40   │     </license>
  41   │   </licenses>
  42   │   <scm>
  43   │     <url>scm:git@github.com:micronaut-projects/micronaut-gcp.git</url>
  44   │     <connection>scm:git@github.com:micronaut-projects/micronaut-gcp.git</connection>
  45   │     <developerConnection>scm:git@github.com:micronaut-projects/micronaut-gcp.git</developerConnection>
  46   │   </scm>
  47   │   <developers>
  48   │     <developer>
  49   │       <id>graemerocher</id>
  50   │       <name>Graeme Rocher</name>
  51   │     </developer>
  52   │   </developers>
  53   │ </project>
```