### PR TITLE
Honour skipDocumentation when building all javadoc

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
@@ -133,12 +133,15 @@ class MicronautDocsPlugin implements Plugin<Project> {
 
                 subprojects.each { proj ->
                     if(!proj.name != 'docs' && !proj.name.startsWith('examples') ) {
-
-                        proj.tasks.withType(Javadoc).each { javadocTask ->
-                            source += javadocTask.source
-                            classpath += javadocTask.classpath
-                            excludes += javadocTask.excludes
-                            includes += javadocTask.includes
+                        boolean skipDocs = proj.hasProperty('skipDocumentation') ? proj.property('skipDocumentation') as Boolean : false
+                        
+                        if (!skipDocs) {
+                            proj.tasks.withType(Javadoc).each { javadocTask ->
+                                source += javadocTask.source
+                                classpath += javadocTask.classpath
+                                excludes += javadocTask.excludes
+                                includes += javadocTask.includes
+                            }                            
                         }
                     }
                 }


### PR DESCRIPTION
Currently classes from all projects are always included in javadoc regardless of `skipDocumentation` property