### PR TITLE
Do not enforce resolved versions for bom modules

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
@@ -99,12 +99,14 @@ class MicronautPublishingPlugin implements Plugin<Project> {
                             maven(MavenPublication) { publication ->
                                 artifactId( "micronaut-" + project.name.substring(project.name.indexOf('/') + 1) )
 
-                                versionMapping {
-                                    usage('java-api') {
-                                        fromResolutionOf('runtimeClasspath')
-                                    }
-                                    usage('java-runtime') {
-                                        fromResolutionResult()
+                                if (!project.name.endsWith("bom")) {
+                                    versionMapping {
+                                        usage('java-api') {
+                                            fromResolutionOf('runtimeClasspath')
+                                        }
+                                        usage('java-runtime') {
+                                            fromResolutionResult()
+                                        }
                                     }
                                 }
 


### PR DESCRIPTION
Otherwise, there are errors such as:

```
Execution failed for task ':data-bom:generateMetadataFileForMavenPublication'.
> Configuration with name 'runtimeClasspath' not found.
```