### PR TITLE
Fix trailing new line characters in github branch name

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
@@ -201,6 +201,7 @@ class MicronautDocsPlugin implements Plugin<Project> {
 
                 targetDir = file("${buildDir}/docs")
                 String githubBranch='git rev-parse --abbrev-ref HEAD'.execute()?.text ?: 'master'
+                githubBranch = githubBranch.trim()
                 sourceRepo = "https://github.com/${githubSlug}/edit/${githubBranch}/src/main/docs"
                 sourceDir = new File(projectDir, "src/main/docs")
                 propertiesFiles = [ new File(rootProject.projectDir, "gradle.properties") ]

--- a/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
@@ -200,8 +200,7 @@ class MicronautDocsPlugin implements Plugin<Project> {
                 dependsOn copyLocalDocResources
 
                 targetDir = file("${buildDir}/docs")
-                String githubBranch='git rev-parse --abbrev-ref HEAD'.execute()?.text ?: 'master'
-                githubBranch = githubBranch.trim()
+                String githubBranch='git rev-parse --abbrev-ref HEAD'.execute()?.text?.trim() ?: 'master'
                 sourceRepo = "https://github.com/${githubSlug}/edit/${githubBranch}/src/main/docs"
                 sourceDir = new File(projectDir, "src/main/docs")
                 propertiesFiles = [ new File(rootProject.projectDir, "gradle.properties") ]


### PR DESCRIPTION
Fixes the issue mentioned [here](https://github.com/micronaut-projects/micronaut-docs/issues/23)

command to fetch branch name: `git rev-parse --abbrev-ref HEAD` returns a trialing newline character after branch name.