### PR TITLE
Minor fixes to the publishing and catalog plugins

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
@@ -99,7 +99,7 @@ class MicronautPublishingPlugin implements Plugin<Project> {
                     repositories {
                         maven {
                             name = "Build"
-                            url = "${layout.buildDirectory.dir("repo").get().asFile.toURI()}"
+                            url = "${rootProject.layout.buildDirectory.dir("repo").get().asFile.toURI()}"
                         }
                     }
                     publications {

--- a/src/main/java/io/micronaut/build/catalogs/MicronautVersionCatalogUpdatePlugin.java
+++ b/src/main/java/io/micronaut/build/catalogs/MicronautVersionCatalogUpdatePlugin.java
@@ -7,6 +7,7 @@ import io.micronaut.build.catalogs.tasks.VersionCatalogUpdate;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
 import java.util.Arrays;
@@ -17,17 +18,19 @@ public class MicronautVersionCatalogUpdatePlugin implements Plugin<Project> {
         if (project != project.getRootProject()) {
             throw new IllegalStateException("The " + MicronautVersionCatalogUpdatePlugin.class.getName() + " plugin must be applied on the root project only");
         }
-        TaskProvider<VersionCatalogUpdate> updater = project.getTasks().register("updateVersionCatalogs", VersionCatalogUpdate.class, task -> {
+        TaskContainer tasks = project.getTasks();
+        TaskProvider<VersionCatalogUpdate> updater = tasks.register("updateVersionCatalogs", VersionCatalogUpdate.class, task -> {
             task.getCatalogsDirectory().convention(project.getLayout().getProjectDirectory().dir("gradle"));
             task.getOutputDirectory().convention(project.getLayout().getProjectDirectory().dir("gradle/updates"));
             task.getRejectedQualifiers().convention(Arrays.asList("alpha", "beta", "rc", "cr", "m", "preview", "b", "ea"));
             task.getIgnoredModules().convention(Collections.emptySet());
             task.getAllowMajorUpdates().convention(false);
         });
-        project.getTasks().register("useLatestVersions", Copy.class, task -> {
+        tasks.register("useLatestVersions", Copy.class, task -> {
             VersionCatalogUpdate dependent = updater.get();
             task.from(dependent.getOutputDirectory());
             task.into(dependent.getCatalogsDirectory());
         });
+        tasks.register("dependencyUpdates", task -> task.setDescription("Compatibility task with the old update mechanism"));
     }
 }


### PR DESCRIPTION
This PR fixes a couple of issues:

1. the local publication repository (in the "build" directory) should have used the root project build directory instead of each subproject directory
2. the "dependencyUpdates" task is called from some CI jobs, but it was missing if the new version catalog dependency updates plugin was applied instead of the old one
