### PR TITLE
Fix catalog update task to support empty versions

### DIFF
--- a/src/main/java/io/micronaut/build/catalogs/tasks/VersionCatalogUpdate.java
+++ b/src/main/java/io/micronaut/build/catalogs/tasks/VersionCatalogUpdate.java
@@ -166,6 +166,7 @@ public abstract class VersionCatalogUpdate extends DefaultTask {
             model.getLibrariesTable()
                     .stream()
                     .filter(library -> !ignoredModules.contains(library.getModule()))
+                    .filter(library -> library.getVersion().getReference() != null || !requiredVersionOf(library).isEmpty())
                     .map(library -> requirePom(dependencies, library))
                     .forEach(dependency -> detachedConfiguration.getDependencies().add(dependency));
 
@@ -243,6 +244,17 @@ public abstract class VersionCatalogUpdate extends DefaultTask {
                 throw new GradleException("Some modules couldn't be updated because of the following reasons:" + errors);
             }
         }
+    }
+
+    private static String requiredVersionOf(Library library) {
+        RichVersion version = library.getVersion().getVersion();
+        if (version != null) {
+            String require = version.getRequire();
+            if (require != null) {
+                return require;
+            }
+        }
+        return "";
     }
 
     private static Dependency requirePom(DependencyHandler dependencies, Library library) {


### PR DESCRIPTION
Following a conversation with @ilopmar a new pattern will be introduced in our version catalog, where we actually want to use a dependency version from another BOM, so we don't want to define the version in our catalog, for internal use.

This commit fixes dependency upgrades whenever a version is empty, to support patterns like:

```toml
my-lib = { module = "foo:bar", version = "" }
```

In this case the version wouldn't be updated since we want to keep it empty.