### PR TITLE
Introduce a shared settings plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     implementation('org.xhtmlrenderer:core-renderer:8.0') {
         exclude group: 'bouncycastle', module:'bcprov-jdk14'
     }
+    implementation 'com.gradle:gradle-enterprise-gradle-plugin:3.7'
+    implementation 'org.nosphere.gradle.github:gradle-github-actions-plugin:1.3.2'
 
     implementation 'org.tomlj:tomlj:1.0.0'
 
@@ -127,6 +129,10 @@ gradlePlugin {
         docs {
             id = 'io.micronaut.build.internal.docs'
             implementationClass = 'io.micronaut.build.MicronautDocsPlugin'
+        }
+        sharedSettings {
+            id = 'io.micronaut.build.shared.settings'
+            implementationClass = 'io.micronaut.build.MicronautSharedSettingsPlugin'
         }
     }
 }

--- a/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
+import com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin;
+import com.gradle.scan.plugin.BuildScanExtension;
+import org.gradle.api.Plugin;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.api.provider.ProviderFactory;
+import org.nosphere.gradle.github.ActionsPlugin;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class MicronautSharedSettingsPlugin implements Plugin<Settings> {
+    @Override
+    public void apply(Settings settings) {
+        settings.getPluginManager().apply(GradleEnterprisePlugin.class);
+        GradleEnterpriseExtension ge = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
+        configureGradleEnterprise(settings, ge);
+    }
+
+    private void configureGradleEnterprise(Settings settings, GradleEnterpriseExtension ge) {
+        ProviderFactory providers = settings.getProviders();
+        boolean isCI = guessCI(providers);
+        configureBuildScansPublishing(ge, isCI);
+        settings.getGradle().projectsLoaded(MicronautSharedSettingsPlugin::applyGitHubActionsPlugin);
+    }
+
+    private void configureBuildScansPublishing(GradleEnterpriseExtension ge, boolean isCI) {
+        ge.setServer("https://ge.micronaut.io");
+        ge.buildScan(buildScan -> {
+            buildScan.publishAlways();
+            if (isCI) {
+                buildScan.setUploadInBackground(false);
+                buildScan.tag("CI");
+            } else {
+                buildScan.tag("LOCAL");
+                publishIfAuthenticated(buildScan);
+            }
+        });
+    }
+
+    private static void applyGitHubActionsPlugin(Gradle gradle) {
+        gradle.getRootProject().getPluginManager().apply(ActionsPlugin.class);
+    }
+
+    private static void publishIfAuthenticated(BuildScanExtension ext) {
+        try {
+            ext.getClass().getMethod("publishIfAuthenticated").invoke(ext);
+        } catch (IllegalAccessException  | InvocationTargetException | NoSuchMethodException e) {
+            System.err.println("Unable to set publish if authenticated on build scan extension");
+        }
+    }
+
+    private static boolean guessCI(ProviderFactory providers) {
+        return providers
+                .environmentVariable("CI").forUseAtConfigurationTime()
+                .map(s -> // Not all workflows may have the enterprise key set
+                        providers.environmentVariable("GRADLE_ENTERPRISE_ACCESS_KEY")
+                                .forUseAtConfigurationTime()
+                                .map(env -> true)
+                                .orElse(false)
+                                .get()
+                )
+                .orElse(false)
+                .get();
+    }
+}


### PR DESCRIPTION
This plugin must be applied on the `settings.gradle` file itself. For now, it only configures the Gradle Enterprise extension, but
it can be used to do much more, including enabling version catalogs, etc...