### PR TITLE
Fix Gradle 8 deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "io.micronaut:micronaut-inject:$micronautVersion"
     // TODO: upgrade to new asciidoctor
     implementation 'org.asciidoctor:asciidoctorj:1.5.6'
-    implementation "io.spring.nohttp:nohttp-gradle:0.0.8"
+    implementation "io.spring.nohttp:nohttp-gradle:0.0.10"
     implementation "com.github.ben-manes:gradle-versions-plugin:0.38.0"
     implementation "com.diffplug.spotless:spotless-plugin-gradle:5.14.2"
     implementation "com.adarshr:gradle-test-logger-plugin:3.0.0"

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -20,7 +20,8 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.repositories.mavenCentral()
         project.setVersion project.findProperty("projectVersion")
-        MicronautBuildExtension micronautBuild = project.extensions.create('micronautBuild', MicronautBuildExtension)
+        BuildEnvironment buildEnvironment = new BuildEnvironment(project.providers)
+        MicronautBuildExtension micronautBuild = project.extensions.create('micronautBuild', MicronautBuildExtension, buildEnvironment)
         configureJavaPlugin(project, micronautBuild)
         configureDependencies(project, micronautBuild)
         configureTasks(project)
@@ -112,8 +113,8 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
             jvmArgs '-Duser.country=US'
             jvmArgs '-Duser.language=en'
 
-            reports.html.enabled = !System.getenv("GITHUB_ACTIONS")
-            reports.junitXml.enabled = true
+            reports.html.required = micronautBuildExtension.environment.isNotGithubAction()
+            reports.junitXml.required = true
 
             String groovyVersion = project.findProperty("groovyVersion")
             if (groovyVersion?.startsWith("3")) {

--- a/src/main/groovy/io/micronaut/build/MicronautBuildExtension.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildExtension.groovy
@@ -2,9 +2,17 @@ package io.micronaut.build
 
 import org.gradle.api.artifacts.ResolutionStrategy
 
-class MicronautBuildExtension {
+import javax.inject.Inject
 
-    /**
+class MicronautBuildExtension {
+    private final BuildEnvironment environment
+
+    @Inject
+    MicronautBuildExtension(BuildEnvironment buildEnvironment) {
+        this.environment = buildEnvironment
+    }
+
+/**
      * The default source compatibility
      */
     String sourceCompatibility = '1.8'
@@ -44,4 +52,7 @@ class MicronautBuildExtension {
         this.resolutionStrategy = closure
     }
 
+    BuildEnvironment getEnvironment() {
+        environment
+    }
 }

--- a/src/main/java/io/micronaut/build/BuildEnvironment.java
+++ b/src/main/java/io/micronaut/build/BuildEnvironment.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+
+public class BuildEnvironment {
+
+    private final ProviderFactory providers;
+    private final Provider<Boolean> githubAction;
+
+    public BuildEnvironment(ProviderFactory providers) {
+        this.providers = providers;
+        this.githubAction = trueWhenEnvVarPresent( "GITHUB_ACTIONS");
+    }
+
+    public Provider<Boolean> isGithubAction() {
+        return githubAction;
+    }
+
+    public Provider<Boolean> isNotGithubAction() {
+        return githubAction.map(b -> !b);
+    }
+
+    public Provider<Boolean> trueWhenEnvVarPresent(String envVar) {
+        return providers.environmentVariable(envVar)
+                .forUseAtConfigurationTime()
+                .map(s -> true)
+                .orElse(false);
+    }
+}

--- a/src/test/groovy/io/micronaut/build/MicronautBuildExtensionSpec.groovy
+++ b/src/test/groovy/io/micronaut/build/MicronautBuildExtensionSpec.groovy
@@ -8,7 +8,7 @@ class MicronautBuildExtensionSpec extends Specification {
     @Unroll
     void "dependencyUpdatesPattern excludes non GA version: #version"(String version, boolean expectedMatch) {
         given:
-        String pattern = new MicronautBuildExtension().dependencyUpdatesPattern
+        String pattern = new MicronautBuildExtension(null).dependencyUpdatesPattern
 
         when:
         boolean matches = version ==~ pattern


### PR DESCRIPTION
This commit fixes the Gradle 8 deprecation warnings by upgrading to
the latest nohttp plugin version and using the required property
for reports instead of "enabled".

In order to make future upgrades easier, it also introduces the
notion of "build environment" in the Micronaut build extension.
For now the build environment is limited to telling if it runs
within a GitHub action or not.