### PR TITLE
Avoid eager creation of javadoc/sources tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,19 +94,16 @@ configurations.all {
     }
 }
 
-task docFilesJar(type: Jar, description: 'Package up files used for generating documentation.') {
+tasks.register('docFilesJar', Jar) {
+    description = 'Package up files used for generating documentation.'
     archiveVersion = null
     archiveFileName = "grails-doc-files.jar"
     from "src/main/template"
-    doLast {
-        copy {
-            from docFilesJar.archivePath
-            into "${buildDir}/classes/groovy/main"
-        }
-    }
 }
 
-jar.dependsOn docFilesJar
+tasks.named('jar', Jar) {
+    from docFilesJar
+}
 
 
 gradlePlugin {

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -174,8 +174,12 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
 
                     showViolations = true
                 }
-                checkstyleTest.enabled = false
-                checkstyleMain.dependsOn('spotlessCheck')
+                tasks.named('checkstyleTest') {
+                    enabled = false
+                }
+                tasks.named('checkstyleMain') {
+                    dependsOn('spotlessCheck')
+                }
             }
         }
     }

--- a/src/main/groovy/io/micronaut/build/MicronautDependencyUpdatesPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautDependencyUpdatesPlugin.groovy
@@ -24,7 +24,8 @@ class MicronautDependencyUpdatesPlugin implements Plugin<Project> {
             if (project.extensions.findByType(MicronautBuildExtension)) {
                 micronautBuildExtension = project.extensions.getByType(MicronautBuildExtension)
             } else {
-                micronautBuildExtension = project.extensions.create('micronautBuild', MicronautBuildExtension)
+                BuildEnvironment buildEnvironment = new BuildEnvironment(project.providers)
+                micronautBuildExtension = project.extensions.create('micronautBuild', MicronautBuildExtension, buildEnvironment)
             }
 
             project.configurations.all { Configuration cfg ->

--- a/src/main/java/io/micronaut/build/BuildEnvironment.java
+++ b/src/main/java/io/micronaut/build/BuildEnvironment.java
@@ -22,10 +22,14 @@ public class BuildEnvironment {
 
     private final ProviderFactory providers;
     private final Provider<Boolean> githubAction;
+    private final boolean isMigrationActive;
 
     public BuildEnvironment(ProviderFactory providers) {
         this.providers = providers;
         this.githubAction = trueWhenEnvVarPresent( "GITHUB_ACTIONS");
+        this.isMigrationActive = !providers.systemProperty("strictBuild")
+                .forUseAtConfigurationTime()
+                .isPresent();
     }
 
     public Provider<Boolean> isGithubAction() {
@@ -41,5 +45,11 @@ public class BuildEnvironment {
                 .forUseAtConfigurationTime()
                 .map(s -> true)
                 .orElse(false);
+    }
+
+    public void duringMigration(Runnable action) {
+        if (isMigrationActive) {
+            action.run();
+        }
     }
 }


### PR DESCRIPTION
This commit updates the plugins to avoid the creation of tasks at configuration
time. This will make the build faster and should eventually help us getting
rid of the many afterEvaluates that bloat the build.

Unfortunately, some of those changes are potentially breaking so a compatibility
mode has been introduced, and some builds can run with the `-DstrictBuild` flag
to be stricter and avoid some configuration.

It also fixes some weird task dependencies, but there are probably many more of them.
