### PR TITLE
Fix nexus publishing plugin

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
@@ -33,6 +33,9 @@ class MicronautPublishingPlugin implements Plugin<Project> {
             }
         }
 
+        def ossUser = System.getenv("SONATYPE_USERNAME") ?: project.hasProperty("sonatypeOssUsername") ? project.sonatypeOssUsername : ''
+        def ossPass = System.getenv("SONATYPE_PASSWORD") ?: project.hasProperty("sonatypeOssPassword") ? project.sonatypeOssPassword : ''
+
         project.with {
             apply plugin: 'maven-publish'
             plugins.withId('java-base') {
@@ -53,8 +56,6 @@ class MicronautPublishingPlugin implements Plugin<Project> {
                 }
             }
             ExtraPropertiesExtension ext = extensions.getByType(ExtraPropertiesExtension)
-            def ossUser = System.getenv("SONATYPE_USERNAME") ?: project.hasProperty("sonatypeOssUsername") ? project.sonatypeOssUsername : ''
-            def ossPass = System.getenv("SONATYPE_PASSWORD") ?: project.hasProperty("sonatypeOssPassword") ? project.sonatypeOssPassword : ''
             ext."signing.keyId" = System.getenv("GPG_KEY_ID") ?: project.hasProperty("signing.keyId") ? project.getProperty('signing.keyId') : null
             ext."signing.password" = System.getenv("GPG_PASSWORD") ?: project.hasProperty("signing.password") ? project.getProperty('signing.password') : null
             def githubSlug = project.findProperty('githubSlug')
@@ -97,7 +98,6 @@ class MicronautPublishingPlugin implements Plugin<Project> {
                     ext.extraPomInfo.call()
                 }
             }
-
 
             afterEvaluate {
                 boolean isPlatform = project.plugins.findPlugin("java-platform") != null
@@ -256,7 +256,6 @@ class MicronautPublishingPlugin implements Plugin<Project> {
                 }
 
 
-                rootProject.plugins.apply('io.github.gradle-nexus.publish-plugin')
                 NexusPublishExtension nexusPublish = rootProject.extensions.getByType(NexusPublishExtension)
                 nexusPublish.with {
                     if (repositories.isEmpty()) {

--- a/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
@@ -36,6 +36,23 @@ public class MicronautSharedSettingsPlugin implements Plugin<Settings> {
         pluginManager.apply(CommonCustomUserDataGradlePlugin.class);
         GradleEnterpriseExtension ge = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
         configureGradleEnterprise(settings, ge);
+        applyPublishingPlugin(settings);
+    }
+
+    private void applyPublishingPlugin(Settings settings) {
+        ProviderFactory providers = settings.getProviders();
+        String ossUser = envOrSystemProperty(providers, "SONATYPE_USERNAME", "sonatypeOssUsername");
+        String ossPass = envOrSystemProperty(providers, "SONATYPE_PASSWORD", "sonatypeOssPassword");
+        if (!ossUser.isEmpty() && !ossPass.isEmpty()) {
+            settings.getGradle().projectsLoaded(gradle -> gradle.getRootProject().getPlugins().apply("io.github.gradle-nexus.publish-plugin"));
+        }
+    }
+
+    private static String envOrSystemProperty(ProviderFactory providers, String envName, String propertyName) {
+        return providers.environmentVariable(envName)
+                .forUseAtConfigurationTime()
+                .orElse(providers.gradleProperty(propertyName).forUseAtConfigurationTime())
+                .getOrElse("");
     }
 
     private void configureGradleEnterprise(Settings settings, GradleEnterpriseExtension ge) {


### PR DESCRIPTION
The MicronautPublishingPlugin was trying to apply the Nexus publishing
plugin to the root project if the Nexus environment variables (or
system properties) were set. Unfortunately, this causes issues because
the evaluation of the root project is done when this happen.

Instead, the plugin will now properly be applied to the root project
if the variables are set, but it's done in a correct place (via the
settings plugin to avoid having to apply more plugins to the root
project).