### PR TITLE
Introduce a "base" module plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,10 @@ gradlePlugin {
             id = 'io.micronaut.build.internal.common'
             implementationClass = 'io.micronaut.build.MicronautBuildCommonPlugin'
         }
+        'base-module' {
+            id = 'io.micronaut.build.internal.base-module'
+            implementationClass = 'io.micronaut.build.MicronautBaseModulePlugin'
+        }
         module {
             id = 'io.micronaut.build.internal.module'
             implementationClass = 'io.micronaut.build.MicronautModulePlugin'

--- a/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.build
+
+import groovy.transform.CompileStatic
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.tasks.testing.Test
+
+/**
+ * Configures a project as a typical Micronaut module project:
+ *  - with dependency updates plugin
+ *  - published on a Maven repository
+ *  - with JUnit platform testing
+ */
+@CompileStatic
+class MicronautBaseModulePlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        project.pluginManager.apply(MicronautBuildCommonPlugin)
+        project.pluginManager.apply(MicronautDependencyUpdatesPlugin)
+        project.pluginManager.apply(MicronautPublishingPlugin)
+        configureJUnit(project)
+    }
+
+    private static void configureJUnit(Project project) {
+        project.tasks.withType(Test).configureEach { Test test ->
+            test.useJUnitPlatform()
+        }
+    }
+
+}

--- a/src/main/groovy/io/micronaut/build/MicronautModulePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautModulePlugin.groovy
@@ -16,17 +16,8 @@ import org.gradle.api.tasks.testing.Test
 class MicronautModulePlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.pluginManager.apply(MicronautBuildCommonPlugin)
-        project.pluginManager.apply(MicronautDependencyUpdatesPlugin)
-        project.pluginManager.apply(MicronautPublishingPlugin)
+        project.pluginManager.apply(MicronautBaseModulePlugin)
         configureStandardDependencies(project)
-        configureJUnit(project)
-    }
-
-    private static void configureJUnit(Project project) {
-        project.tasks.withType(Test).configureEach { Test test ->
-            test.useJUnitPlatform()
-        }
     }
 
     private static Dependency configureStandardDependencies(Project project) {


### PR DESCRIPTION
Some modules may not want to add the standard dependencies, because they are
not runtime modules. A typical example is that AOT module which doesn't use
annotation processing and will never be found on a user classpath.