### PR TITLE
Fix how the nexus repositories are added

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
@@ -3,9 +3,10 @@ package io.micronaut.build
 import groovy.transform.CompileStatic
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.internal.GradleInternal
 import org.gradle.api.tasks.testing.Test
+
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Configures a project as a typical Micronaut module project:
@@ -15,12 +16,15 @@ import org.gradle.api.tasks.testing.Test
  */
 @CompileStatic
 class MicronautBaseModulePlugin implements Plugin<Project> {
+    private final static AtomicBoolean WARNING_ISSUED = new AtomicBoolean()
+
     @Override
     void apply(Project project) {
         project.pluginManager.apply(MicronautBuildCommonPlugin)
         project.pluginManager.apply(MicronautDependencyUpdatesPlugin)
         project.pluginManager.apply(MicronautPublishingPlugin)
         configureJUnit(project)
+        assertSettingsPluginApplied(project)
     }
 
     private static void configureJUnit(Project project) {
@@ -29,4 +33,33 @@ class MicronautBaseModulePlugin implements Plugin<Project> {
         }
     }
 
+    static void assertSettingsPluginApplied(Project project) {
+        def plugin = ((GradleInternal) project.gradle).getSettings().getPlugins().findPlugin("io.micronaut.build.shared.settings")
+        if (plugin == null) {
+            if (!WARNING_ISSUED.getAndSet(true)) {
+                project.gradle.buildFinished {
+                    project.logger.warn("""
+WARNING!
+
+The internal Micronaut Build plugins have been updated, but the settings plugin hasn't been applied.
+You must apply the shared settings plugin by modifying the settings.gradle(.kts) file by adding on the top:
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id("io.micronaut.build.shared.settings") version "<plugin version>"
+}
+
+Not doing so will result in a failure when publishing.
+
+""")
+                }
+            }
+        }
+    }
 }

--- a/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.build
 
 import io.github.gradlenexus.publishplugin.InitializeNexusStagingRepository
-import io.github.gradlenexus.publishplugin.NexusPublishExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
@@ -18,9 +17,6 @@ import org.gradle.plugins.signing.Sign
  * Micronaut internal Gradle plugin. Not intended to be used in user's projects.
  */
 class MicronautPublishingPlugin implements Plugin<Project> {
-
-
-    public static final String NEXUS_STAGING_PROFILE_ID = "11bd7bc41716aa"
 
     @Override
     void apply(Project project) {
@@ -250,24 +246,6 @@ class MicronautPublishingPlugin implements Plugin<Project> {
                             }
                             tasks.withType(Sign) {
                                 onlyIf { !project.version.endsWith("-SNAPSHOT") }
-                            }
-                        }
-                    }
-                }
-
-
-                NexusPublishExtension nexusPublish = rootProject.extensions.getByType(NexusPublishExtension)
-                nexusPublish.with {
-                    if (repositories.isEmpty()) {
-                        repositoryDescription = "${project.group}:${rootProject.name}:${project.version}"
-                        useStaging = !project.version.endsWith("-SNAPSHOT")
-                        repositories {
-                            sonatype {
-                                username = ossUser
-                                password = ossPass
-                                nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
-                                snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-                                stagingProfileId = NEXUS_STAGING_PROFILE_ID //can reduce execution time by even 10 seconds
                             }
                         }
                     }


### PR DESCRIPTION
This commit fixes yet another ordering issue. The use of `afterEvaluate` on
_any_ project to add configuration to the _root_ project is doomed to fail in
some form. Here, it was possible that the configuration of a child module was
completed before the root project was. In this case, the Nexus repository
wouldn't be added, which leads to incomplete publications!

This commit fixes the problem by making sure that the repository is added
first. It also introduces a sanity check to make sure that if the plugin is
updated, it also comes with the application of the settings plugin.