### PR TITLE
Fix javadoc/sources publishing

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
@@ -147,10 +147,15 @@ class MicronautPublishingPlugin implements Plugin<Project> {
                                 }
 
                                 if(project.hasProperty('shadowJarEnabled') && project.shadowJarEnabled == true) {
+                                    // TODO: This code doesn't use Gradle publications, it hard codes publishing
+                                    // which is easy to break and causes Gradle Module Metadata to be ignored
+                                    // this should be replaced with a publication
                                     def shadowJar = tasks.findByName("shadowJar")
                                     artifact(project.tasks.shadowJar) {
                                         classifier = null
                                     }
+                                    artifact(tasks.named('javadocJar'))
+                                    artifact(tasks.named('sourcesJar'))
                                     pom.withXml { xml ->
                                         def xmlNode = xml.asNode()
                                         def dependenciesNode = xmlNode.appendNode('dependencies')


### PR DESCRIPTION
This commit fixes javadocs and sources publishing for modules which use
shadow jar: in this case, the publishing mechanism does NOT use standard
Gradle publications. This caused the javadocs/sources to be ignored.

In order to check that publishing works properly, there's now the
possibility to override the default sonatype URIs, in order to verify
publication locally for example.

The following env vars/system properties were added:

- allowInsecurePublishing: lets Gradle publish on a repository which
doesn't use https. Useful for dry run deployments on local repos
- SONATYPE_REPO_URI/sonatypeRepoUri : the URI of a sonatype server where
to publish releases
- SONATYPE_SNAPSHOT_REPO_URI/sonatypeSnapshotRepoUri: the URI of a nexus
repository where to publish snapshots