### PR TITLE
Introduce a BOM plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,14 @@ gradlePlugin {
             id = 'io.micronaut.build.internal.module'
             implementationClass = 'io.micronaut.build.MicronautModulePlugin'
         }
+        bom {
+            id = 'io.micronaut.build.internal.bom'
+            implementationClass = 'io.micronaut.build.MicronautBomPlugin'
+        }
+        bomChecker {
+            id = 'io.micronaut.build.internal.bom-checker'
+            implementationClass = 'io.micronaut.build.MicronautBomCheckerPlugin'
+        }
         publishing {
             id = 'io.micronaut.build.internal.publishing'
             implementationClass = 'io.micronaut.build.MicronautPublishingPlugin'

--- a/src/main/groovy/io/micronaut/build/MicronautBasePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBasePlugin.groovy
@@ -33,7 +33,7 @@ class MicronautBasePlugin implements Plugin<Project> {
     void apply(Project project) {
         addMavenCentral(project)
         configureProjectVersion(project)
-        createBuildExtension(project)
+        project.pluginManager.apply(MicronautBuildExtensionPlugin)
         project.pluginManager.apply(ConfigurationPropertiesPlugin)
     }
 
@@ -48,11 +48,6 @@ class MicronautBasePlugin implements Plugin<Project> {
         if (repositoriesMode != repositoriesMode.FAIL_ON_PROJECT_REPOS) {
             project.repositories.mavenCentral()
         }
-    }
-
-    private void createBuildExtension(Project project) {
-        def buildEnvironment = new BuildEnvironment(project.providers)
-        project.extensions.create("micronautBuild", MicronautBuildExtension, buildEnvironment)
     }
 
 }

--- a/src/main/groovy/io/micronaut/build/MicronautBomCheckerPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBomCheckerPlugin.groovy
@@ -1,0 +1,71 @@
+package io.micronaut.build
+
+
+import io.micronaut.build.pom.PomChecker
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.artifacts.repositories.ArtifactRepository
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+/**
+ * This plugin verifies the BOMs which are used in the project
+ * version catalog.
+ */
+abstract class MicronautBomCheckerPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+
+        def catalog = project.extensions.findByType(VersionCatalogsExtension).named("libs")
+        project.with {
+            def checkBoms = tasks.register("checkBom")
+
+            project.tasks.register("check") {
+                dependsOn(checkBoms)
+            }
+
+            // First we create a task per BOM that we include, in order
+            // to check that they exist for the specified version and
+            // that their dependencyManagement block only contains expected
+            // dependencies
+            catalog.dependencyAliases.stream()
+                    .filter { it.startsWith("boms.") }
+                    .forEach { alias ->
+                        String name = alias.split("[.]").collect { it.capitalize() }.join('')
+                        def checker = tasks.register("check$name", PomChecker) {
+                            repositories.set([repoUrl(project.repositories.findByName("MavenRepo"))])
+                            pomCoordinates.set(catalog.findDependency(alias).map {
+                                it.map { "${it.module.group}:${it.module.name}:${it.versionConstraint.requiredVersion}".toString() }
+                            }.get())
+                            checkBomContents.set(true)
+                            report.set(layout.buildDirectory.file("reports/boms/${alias}.txt"))
+                        }
+                        checkBoms.configure {
+                            it.dependsOn(checker)
+                        }
+                    }
+
+            // Then we create a task per dependency we include in the BOM
+            // to check that it exists
+            catalog.dependencyAliases.stream()
+                    .filter { it.startsWith("managed.") }
+                    .forEach { alias ->
+                        String name = alias.split("[.]").collect { it.capitalize() }.join('')
+                        def checker = tasks.register("check$name", PomChecker) {
+                            repositories.set([repoUrl(project.repositories.findByName("MavenRepo"))] + project.repositories.collect { repoUrl(it) })
+                            pomCoordinates.set(catalog.findDependency(alias).map {
+                                it.map { "${it.module.group}:${it.module.name}:${it.versionConstraint.requiredVersion}".toString() }
+                            }.get())
+                            checkBomContents.set(false)
+                            report.set(layout.buildDirectory.file("reports/dependencies/${alias}.txt"))
+                        }
+                        checkBoms.configure {
+                            it.dependsOn(checker)
+                        }
+                    }
+        }
+    }
+
+    static String repoUrl(ArtifactRepository repository) {
+        (repository as MavenArtifactRepository).url
+    }
+}

--- a/src/main/groovy/io/micronaut/build/MicronautBomPlugin.java
+++ b/src/main/groovy/io/micronaut/build/MicronautBomPlugin.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+import groovy.lang.Closure;
+import groovy.namespace.QName;
+import groovy.util.Node;
+import io.micronaut.build.pom.MicronautBomExtension;
+import io.micronaut.build.pom.PomChecker;
+import io.micronaut.build.pom.VersionCatalogConverter;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.VersionCatalog;
+import org.gradle.api.artifacts.VersionCatalogsExtension;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.component.AdhocComponentWithVariants;
+import org.gradle.api.plugins.JavaPlatformExtension;
+import org.gradle.api.plugins.JavaPlatformPlugin;
+import org.gradle.api.plugins.PluginManager;
+import org.gradle.api.plugins.catalog.CatalogPluginExtension;
+import org.gradle.api.plugins.catalog.VersionCatalogPlugin;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.publish.maven.tasks.GenerateMavenPom;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This plugin configures a Micronaut module as a platform,
+ * that is to say something which publishes a BOM file (or
+ * a Gradle catalog).
+ *
+ * A BOM can be created from the version catalog which is
+ * used to build the project itself. In this case, the
+ * dependencies which must appear in the BOM have to be
+ * prefixed with `managed-`.
+ */
+@SuppressWarnings({"UnstableApiUsage", "HardCodedStringLiteral"})
+public abstract class MicronautBomPlugin implements Plugin<Project> {
+
+    public static final List<String> DEPENDENCY_PATH = Arrays.asList("dependencyManagement", "dependencies", "dependency");
+
+    @Override
+    public void apply(Project project) {
+        PluginManager plugins = project.getPluginManager();
+        plugins.apply(JavaPlatformPlugin.class);
+        plugins.apply(VersionCatalogPlugin.class);
+        plugins.apply(MicronautBuildExtensionPlugin.class);
+        plugins.apply(MicronautPublishingPlugin.class);
+        MicronautBomExtension bomExtension = project.getExtensions().create("micronautBom", MicronautBomExtension.class);
+        bomExtension.getPublishCatalog().convention(true);
+        bomExtension.getIncludeBomInCatalog().convention(true);
+        bomExtension.getImportProjectCatalog().convention(true);
+        bomExtension.getExcludeProject().convention(p -> p.getName().contains("bom") || p.getName().startsWith("test-suite") || !p.getSubprojects().isEmpty());
+        bomExtension.getExtraExcludedProjects().add(project.getName());
+        bomExtension.getCatalogToPropertyNameOverrides().convention(Collections.emptyMap());
+        configureBOM(project, bomExtension);
+    }
+
+    private static String nameOf(Node n) {
+        Object name = n.name();
+        if (name instanceof String) {
+            return (String) name;
+        }
+        return ((QName) n.name()).getLocalPart();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Stream<Node> forEachNode(Node node, List<String> path) {
+        if (path.isEmpty()) {
+            return Stream.empty();
+        }
+        String child = path.get(0);
+        List<Node> children = (List<Node>) node.children();
+        if (path.size() == 1) {
+            return children.stream().filter(n -> nameOf(n).equals(child));
+        } else {
+            return children
+                    .stream()
+                    .filter(n -> nameOf(n).equals(child))
+                    .flatMap(n -> forEachNode(n, path.subList(1, path.size())));
+
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+
+    private Node childOf(Node node, String name) {
+        List<Node> children = (List<Node>) node.children();
+        return children.stream().filter(n -> nameOf(n).equals(name))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static String removePrefix(String str, String prefix) {
+        if (str.startsWith(prefix)) {
+            return str.substring(prefix.length());
+        }
+        return str;
+    }
+
+    private static String toPropertyName(String alias) {
+        return Arrays.stream(alias.split("(?=[A-Z])"))
+                .map(s -> s.toLowerCase(Locale.US))
+                .collect(Collectors.joining("-"))
+                .replace('-', '.');
+    }
+
+    private String bomPropertyName(MicronautBomExtension ext, String alias) {
+        alias = removePrefix(alias, "managed.");
+        alias = removePrefix(alias, "boms.");
+        String baseName = ext.getCatalogToPropertyNameOverrides().getting(alias).getOrElse(toPropertyName(alias));
+        return baseName + ".version";
+    }
+
+    private static void forEachProject(MicronautBomExtension ext, Project project, Consumer<? super Project> consumer) {
+        Set<String> excludedProjects = ext.getExtraExcludedProjects().get();
+        Spec<? super Project> excludeSpec = ext.getExcludeProject().get();
+        for (Project p : project.getRootProject().getSubprojects()) {
+            if (excludeSpec.isSatisfiedBy(p) || excludedProjects.contains(p.getName())) {
+                continue;
+            }
+            consumer.accept(p);
+        }
+    }
+
+    private static String assertVersion(Project p) {
+        String version = String.valueOf(p.getVersion());
+        if (version.isEmpty() || "unspecified".equals(version)) {
+            throw new GradleException("Version of " + p.getPath() + " is undefined!");
+        }
+        return version;
+    }
+
+    private void configureBOM(Project project, MicronautBomExtension bomExtension) {
+        PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
+        JavaPlatformExtension javaPlatformExtension = project.getExtensions().getByType(JavaPlatformExtension.class);
+        javaPlatformExtension.allowDependencies();
+        publishing.getPublications().create("maven", MavenPublication.class);
+        TaskContainer tasks = project.getTasks();
+        project.afterEvaluate(unused -> configureLate(project, bomExtension, publishing, tasks));
+
+        registerCheckBomTask(project, publishing, tasks);
+
+    }
+
+    private void configureLate(Project project, MicronautBomExtension bomExtension, PublishingExtension publishing, TaskContainer tasks) {
+        String publishedName = "micronaut-" + project.getName();
+        String group = String.valueOf(project.getGroup());
+        Optional<VersionCatalog> versionCatalog = findVersionCatalog(project, bomExtension);
+        final VersionCatalogConverter modelConverter = new VersionCatalogConverter(
+                project.getRootProject().file("gradle/libs.versions.toml"),
+                project.getExtensions().findByType(CatalogPluginExtension.class)
+        );
+        tasks.named("generateCatalogAsToml", task -> modelConverter.populateModel());
+        if (bomExtension.getPublishCatalog().get()) {
+            configureVersionCatalog(project, bomExtension, publishedName, group);
+        }
+        publishing.getPublications().named("maven", MavenPublication.class, pub -> {
+            pub.setArtifactId(publishedName);
+            pub.from(project.getComponents().getByName("javaPlatform"));
+            pub.pom(pom -> {
+                pom.setPackaging("pom");
+                pom.withXml(xml -> {
+                    Node node = xml.asNode();
+                    Optional<Node> packagingNode = Optional.ofNullable(childOf(node, "packaging"));
+                    if (project.hasProperty("pomInfo")) {
+                        packagingNode.ifPresent(packaging -> packaging.plus((Closure) project.findProperty("pomInfo")));
+                    }
+                    modelConverter.getModel().getLibrariesTable().forEach(library -> {
+                        String alias = Optional.ofNullable(library.getVersion().getReference()).map(a -> a.replace('-', '.')).orElse("");
+                        String libraryAlias = Optional.ofNullable(library.getAlias()).map(a -> a.replace('-', '.')).orElse("");
+                        if (libraryAlias.startsWith("managed.") || libraryAlias.startsWith("boms.")) {
+                            Optional<Node> pomDep = forEachNode(node, DEPENDENCY_PATH)
+                                    .filter(n ->
+                                            childOf(n, "artifactId").text().equals(library.getName()) &&
+                                                    childOf(n, "groupId").text().equals(library.getGroup()))
+                                    .findFirst();
+                            if (pomDep.isPresent()) {
+                                String bomPropertyName = bomPropertyName(bomExtension, alias);
+                                childOf(pomDep.get(), "version").setValue("${" + bomPropertyName + "}");
+                            } else {
+                                System.err.println("[WARNING] Didn't find library " + library.getGroup() + ":" + library.getName() + " in BOM file");
+                            }
+                        }
+                    });
+
+                    // Add individual module versions as properties
+                    forEachProject(bomExtension, project, p -> {
+                        String propertyName = "micronaut." + p.getName().replace('-', '.');
+                        String projectGroup = String.valueOf(p.getGroup());
+                        Optional<Node> pomDep = forEachNode(node, DEPENDENCY_PATH)
+                                .filter(n -> childOf(n, "artifactId").text().equals("micronaut-" + p.getName()) &&
+                                        childOf(n, "groupId").text().equals(projectGroup))
+                                .findFirst();
+                        if (pomDep.isPresent()) {
+                            childOf(pomDep.get(), "version").setValue("${" + propertyName + "}");
+                        } else {
+                            System.err.println("[WARNING] Didn't find dependency " + projectGroup + ":micronaut-" + p.getName() + " in BOM file");
+                        }
+                    });
+                });
+                versionCatalog.ifPresent(libsCatalog -> libsCatalog.getVersionAliases().forEach(alias -> {
+                    if (alias.startsWith("managed.")) {
+                        libsCatalog.findVersion(alias).ifPresent(version -> {
+                            String propertyName = bomPropertyName(bomExtension, alias);
+                            pom.getProperties().put(propertyName, version.getRequiredVersion());
+                        });
+                    }
+                }));
+                forEachProject(bomExtension, project, p -> {
+                    project.evaluationDependsOn(p.getPath());
+                    String propertyName = "micronaut." + p.getName().replace('-', '.') + ".version";
+                    pom.getProperties().put(propertyName, assertVersion(p));
+                });
+            });
+        });
+
+        Configuration api = project.getConfigurations().getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME);
+        versionCatalog.ifPresent(libsCatalog -> libsCatalog.getDependencyAliases().forEach(alias -> {
+            if (alias.startsWith("boms.")) {
+                api.getDependencies().add(project.getDependencies().platform(libsCatalog.findDependency(alias)
+                        .map(Provider::get)
+                        .orElseThrow(() -> new RuntimeException("Unexpected missing alias in catalog: " + alias))
+                ));
+            } else if (alias.startsWith("managed.")) {
+                api.getDependencyConstraints().add(
+                        project.getDependencies().getConstraints().create(libsCatalog.findDependency(alias).map(Provider::get)
+                                .orElseThrow(() -> new RuntimeException("Unexpected missing alias in catalog: " + alias))));
+            }
+
+        }));
+        forEachProject(bomExtension, project, p -> {
+            project.evaluationDependsOn(p.getPath());
+            String moduleGroup = String.valueOf(p.getGroup());
+            String moduleName = "micronaut-" + p.getName();
+            String moduleVersion = assertVersion(p);
+
+            api.getDependencyConstraints().add(
+                    project.getDependencies()
+                            .getConstraints()
+                            .create(moduleGroup + ":" + moduleName + ":" + moduleVersion)
+            );
+
+            modelConverter.getExtraVersions().put(moduleName, moduleVersion);
+            modelConverter.getExtraLibraries().put(moduleName, VersionCatalogConverter.library(moduleGroup, moduleName, moduleName));
+        });
+    }
+
+    private void registerCheckBomTask(Project project, PublishingExtension publishing, TaskContainer tasks) {
+        TaskProvider<PomChecker> checkBom = tasks.register("checkBom", PomChecker.class, task -> {
+            String repoUrl = "https://repo.maven.apache.org/maven2/";
+            ArtifactRepository repo = publishing.getRepositories().findByName("Build");
+            if (repo instanceof MavenArtifactRepository) {
+                repoUrl = ((MavenArtifactRepository) repo).getUrl().toString();
+            }
+            task.getRepositories().add(repoUrl);
+            task.getPomFile().fileProvider(tasks.named("generatePomFileForMavenPublication", GenerateMavenPom.class).map(GenerateMavenPom::getDestination));
+            String version = assertVersion(project);
+            task.getPomCoordinates().set(String.format("{}:{}:{}", project.getGroup(), "micronaut-" + project.getName(), version));
+            task.getCheckBomContents().set(false);
+            task.getReport().set(project.getLayout().getBuildDirectory().file("reports/boms/micronaut-bom.txt"));
+            task.getFailOnSnapshots().set(!version.endsWith("-SNAPSHOT"));
+            task.getFailOnError().set(true);
+        });
+
+        tasks.named("check", task -> task.dependsOn(checkBom));
+    }
+
+    private static Optional<VersionCatalog> findVersionCatalog(Project project, MicronautBomExtension bomExtension) {
+        if (!bomExtension.getImportProjectCatalog().get()) {
+            return Optional.empty();
+        }
+        VersionCatalogsExtension versionCatalogsExtension = project.getExtensions().findByType(VersionCatalogsExtension.class);
+        return Optional.ofNullable(versionCatalogsExtension).map(e -> e.named("libs"));
+    }
+
+    private void configureVersionCatalog(Project project, MicronautBomExtension bomExtension, String publishedName, String group) {
+        if (bomExtension.getIncludeBomInCatalog().get()) {
+            CatalogPluginExtension catalog = project.getExtensions().getByType(CatalogPluginExtension.class);
+            catalog.versionCatalog(vc -> {
+                String versionName = publishedName.replace('-', '.');
+                vc.alias(publishedName).to(group, publishedName).versionRef(versionName);
+                vc.version(versionName, String.valueOf(project.getVersion()));
+            });
+        }
+        AdhocComponentWithVariants javaPlatform = (AdhocComponentWithVariants) project.getComponents().getByName("javaPlatform");
+        javaPlatform.addVariantsFromConfiguration(project.getConfigurations().getByName(VersionCatalogPlugin.VERSION_CATALOG_ELEMENTS), details -> {
+            details.mapToMavenScope("compile");
+            details.mapToOptional();
+        });
+    }
+
+
+}

--- a/src/main/groovy/io/micronaut/build/MicronautBuildExtensionPlugin.java
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildExtensionPlugin.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * This plugin is responsible for creating the Micronaut Build
+ * extension.
+ */
+public abstract class MicronautBuildExtensionPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        createBuildExtension(project);
+    }
+
+    private void createBuildExtension(Project project) {
+        BuildEnvironment buildEnvironment = new BuildEnvironment(project.getProviders());
+        project.getExtensions().create("micronautBuild", MicronautBuildExtension.class, buildEnvironment);
+    }
+}

--- a/src/main/groovy/io/micronaut/build/MicronautDependencyUpdatesPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautDependencyUpdatesPlugin.groovy
@@ -17,7 +17,7 @@ class MicronautDependencyUpdatesPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        project.pluginManager.apply(MicronautBasePlugin)
+        project.pluginManager.apply(MicronautBuildExtensionPlugin)
         project.apply plugin: GRADLE_VERSIONS_PLUGIN
         project.apply plugin: USE_LATEST_VERSIONS_PLUGIN
 

--- a/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
@@ -10,6 +10,7 @@ import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.plugins.signing.Sign
@@ -20,6 +21,7 @@ class MicronautPublishingPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        project.pluginManager.apply(MavenPublishPlugin)
         def p = project.findProperty("micronautPublish")
         // add option to force publishing
         boolean doPublish = p != null && Boolean.valueOf(p.toString())
@@ -33,7 +35,6 @@ class MicronautPublishingPlugin implements Plugin<Project> {
         def ossPass = System.getenv("SONATYPE_PASSWORD") ?: project.hasProperty("sonatypeOssPassword") ? project.sonatypeOssPassword : ''
 
         project.with {
-            apply plugin: 'maven-publish'
             plugins.withId('java-base') {
                 java {
                     withSourcesJar()

--- a/src/main/groovy/io/micronaut/build/pom/MicronautBomExtension.java
+++ b/src/main/groovy/io/micronaut/build/pom/MicronautBomExtension.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.pom;
+
+import org.gradle.api.Project;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.specs.Spec;
+
+/**
+ * Extension to configure BOM projects.
+ */
+public interface MicronautBomExtension {
+    /**
+     * Excludes projects from the BOM. Any call to this
+     * method will override the default spec which excludes
+     * modules containing the name "bom" or starting with
+     * "test-suite".
+     *
+     * @return the exclusion spec
+     */
+    Property<Spec<? super Project>> getExcludeProject();
+
+    /**
+     * List of project names which shouldn't be included
+     * in the BOM. This list is considered in addition to the
+     * exclusion spec.
+     *
+     * @return the excluded projects
+     */
+    SetProperty<String> getExtraExcludedProjects();
+
+    /**
+     * If set to true, a Gradle version catalog will be published
+     * alongside the BOM file.
+     * @return the catalog property
+     */
+    Property<Boolean> getPublishCatalog();
+
+    /**
+     * If set to true and that a version catalog is used in the project
+     * declaring the BOM, then the BOM will automatically be generated
+     * with elements of the version catalog.
+     * @return the project catalog import property
+     */
+    Property<Boolean> getImportProjectCatalog();
+
+    /**
+     * If set to true, the BOM will be added to the generated
+     * version catalog.
+     * @return the include bom property
+     */
+    Property<Boolean> getIncludeBomInCatalog();
+
+    /**
+     * This property allows overriding the name of the properties
+     * which will appear in the BOM, when they differ from the names
+     * of properties as defined in the project version catalog.
+     *
+     * This property should only be used by legacy projects which
+     * used old property names.
+     *
+     * @return the mapping from catalog property names to BOOM property names
+     */
+    MapProperty<String, String> getCatalogToPropertyNameOverrides();
+}

--- a/src/main/groovy/io/micronaut/build/pom/PomChecker.groovy
+++ b/src/main/groovy/io/micronaut/build/pom/PomChecker.groovy
@@ -1,0 +1,137 @@
+package io.micronaut.build.pom
+
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+import static org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
+
+@CompileStatic
+@CacheableTask
+abstract class PomChecker extends DefaultTask {
+    @Input
+    abstract ListProperty<String> getRepositories()
+
+    @Input
+    abstract Property<String> getPomCoordinates()
+
+    @Input
+    abstract Property<Boolean> getFailOnSnapshots()
+
+    @Input
+    abstract Property<Boolean> getFailOnError()
+
+    @Input
+    abstract Property<Boolean> getFailOnBomContents()
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    @Optional
+    abstract RegularFileProperty getPomFile()
+
+    @Input
+    abstract Property<Boolean> getCheckBomContents()
+
+    @OutputFile
+    abstract RegularFileProperty getReport()
+
+    PomChecker() {
+        description = "Verifies a POM file"
+        group = VERIFICATION_GROUP
+        getFailOnError().convention(true)
+        getFailOnSnapshots().convention(getPomCoordinates().map(v -> !v.endsWith("-SNAPSHOT")))
+        getFailOnBomContents().convention(getPomCoordinates().map(v -> !v.startsWith("io.micronaut")))
+    }
+
+    @TaskAction
+    void verifyBom() {
+        List<String> errors = []
+        boolean found = false
+        for (String repositoryUrl : repositories.get()) {
+            def coordinates = pomCoordinates.get().split(':')
+            if (coordinates.length != 3) {
+                throw new GradleException("Incorrect BOM coordinates '${pomCoordinates.get()}': should be of the form group:artifact:version ")
+            }
+            def (group, artifact, version) = [coordinates[0], coordinates[1], coordinates[2]]
+            if (repositoryUrl.endsWith('/')) {
+                repositoryUrl = repositoryUrl.substring(0, repositoryUrl.length() - 1)
+            }
+            def uri = "$repositoryUrl/${group.replace((char) '.', (char) '/')}/${artifact}/${version}/${artifact}-${version}.pom"
+            try {
+                def pom
+                if (pomFile.present) {
+                    pom = new XmlSlurper().parse(pomFile.asFile.get())
+                } else {
+                    pom = new XmlSlurper().parse(uri)
+                }
+                if (checkBomContents.get()) {
+                    assertDependencyManagementConfinedToGroup(pom, group, artifact, errors)
+                }
+                if (version.endsWith("-SNAPSHOT")) {
+                    String message = "Dependency ${pomCoordinates.get()} is a SNAPSHOT"
+                    if (failOnSnapshots.get()) {
+                        errors << message
+                    } else {
+                        logger.warn(message)
+                    }
+                }
+                found = true
+                break
+            } catch (Exception ex) {
+                getLogger().debug("Skipping repository $repositoryUrl as the POM file is missing or corrupt")
+            }
+        }
+        if (!found) {
+            errors << "Dependency ${pomCoordinates.get()} is wasn't found in any repository".toString()
+        }
+        def reportFile = report.asFile.get()
+        def reportDir = reportFile.parentFile
+        if (reportDir.directory || reportDir.mkdirs()) {
+            reportFile.text = errors.join("\n")
+        } else {
+            throw new GradleException("Unable to write report file to ${reportFile}")
+        }
+        if (errors) {
+            String message = "Validation failed for ${pomCoordinates.get()}. Check the report at ${reportFile} for details."
+            if (failOnError.get()) {
+                throw new GradleException(message)
+            } else {
+                logger.error(message)
+            }
+        }
+    }
+
+    @CompileDynamic
+    private void assertDependencyManagementConfinedToGroup(GPathResult pom, String group, String name, List<String> errors) {
+        boolean failOnError = failOnBomContents.get()
+        String prefix = failOnError ? 'Error validating' : 'Warning:'
+        pom.dependencyManagement.dependencies.dependency.each {
+            String depGroup = it.groupId.text().replace('${project.groupId}', group)
+            if (!depGroup.startsWith(group)) {
+                def scope = it.scope.text()
+                if (scope != 'import') {
+                    String message = "$prefix BOM [${name}]: includes the dependency [${it.groupId}:${it.artifactId}:${it.version}] which doesn't start with the group id of the BOM: [${group}]"
+                    if (failOnError) {
+                        errors << message
+                    } else {
+                        logger.warn(message)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/io/micronaut/build/pom/VersionCatalogConverter.groovy
+++ b/src/main/groovy/io/micronaut/build/pom/VersionCatalogConverter.groovy
@@ -1,0 +1,82 @@
+package io.micronaut.build.pom
+
+import groovy.transform.Canonical
+import io.micronaut.build.catalogs.internal.LenientVersionCatalogParser
+import io.micronaut.build.catalogs.internal.VersionCatalogTomlModel
+import org.gradle.api.InvalidUserCodeException
+import org.gradle.api.plugins.catalog.CatalogPluginExtension
+/**
+ * This is an internal task which responsibility is to parse
+ * the Micronaut version catalog used internally, extract components
+ * which belong to the BOM, in order to populate the version catalog
+ * model for Gradle.
+ *
+ * In the end, this model is used to generate a version catalog in
+ * addition to the bom. This will let users choose between importing
+ * a BOM or using the Micronaut version catalog.
+ *
+ */
+@Canonical
+class VersionCatalogConverter {
+    final File catalogFile
+    final CatalogPluginExtension catalogExtension
+    final Map<String, String> extraVersions = [:]
+    final Map<String, Library> extraLibraries = [:]
+
+    VersionCatalogConverter(File catalogFile, CatalogPluginExtension ext) {
+        this.catalogFile = catalogFile
+        this.catalogExtension = ext
+    }
+
+    private VersionCatalogTomlModel model
+
+    VersionCatalogTomlModel getModel() {
+        if (model == null) {
+            def parser = new LenientVersionCatalogParser()
+            if (catalogFile.exists()) {
+                parser.parse(catalogFile.newInputStream())
+            }
+            model = parser.model
+        }
+        model
+    }
+
+    void populateModel() {
+        catalogExtension.versionCatalog {builder ->
+            extraVersions.forEach { alias, version ->
+                builder.version(alias, version)
+            }
+            extraLibraries.forEach { alias, library ->
+                builder.alias(alias)
+                        .to(library.group, library.name)
+                        .versionRef(library.versionRef)
+            }
+            model.versionsTable.each { version ->
+                if (version.reference.startsWith('managed-')) {
+                    builder.version(version.reference.substring(8), version.version.require)
+                }
+            }
+            model.librariesTable.each { library ->
+                if (library.alias.startsWith("managed-") && library.version.reference) {
+                    if (!library.version.reference.startsWith("managed-")) {
+                        throw new InvalidUserCodeException("Version catalog declares a managed library '${library.alias}' referencing a non managed version '${library.version.reference}'. Make sure to use a managed version.")
+                    }
+                    builder.alias(library.alias.substring(8))
+                            .to(library.group, library.name)
+                            .versionRef(library.version.reference.substring(8))
+                }
+            }
+        }
+    }
+
+    static Library library(String group, String name, String versionRef) {
+        new Library(group, name, versionRef)
+    }
+
+    @Canonical
+    static class Library {
+        final String group
+        final String name
+        final String versionRef
+    }
+}


### PR DESCRIPTION
This commit introduces a couple of BOM plugins, which can be used in any
Micronaut project. The first one, `io.micronaut.internal.bom` is probably
the most interesting to all projects, since it allows the creation of a
BOM for a multi-project.

Instead of having each module define how a BOM is generated, this provides
a conventional way to do it, with an extension to customize the behavior.
A typical Micronaut BOM project would only need to do this:

```gradle
plugins {
    id 'io.micronaut.build.internal.bom'
}

version projectVersion
group projectGroup
```

And this would:

- generate a BOM including all submodules, except well-known modules
(test-suite, bom, ...)
- generate a Gradle version catalog

In addition, if the module is using a Gradle version catalog, then the
BOM can include additional dependencies defined in the catalog, as long
as they are declared using the `managed.` prefix (similarly to what is
available in `micronaut-core`).

Last but not least, all generated BOMs will consistently define property
names for all modules, allowing users to override versions if needed.
The plugin also adds sanity checks (executed during the `check` phase)
to ensure that the BOM only resolves dependencies which exist in Central.

This leads us to the 2d plugin, `io.micronaut.build.internal.bom-checker`
which must be applied to a different subproject, similarly to the module
named `bom-check` in `micronaut-core`: it defines a number of tasks which
responsibility is to verify the imported BOMs. For this reason, it will
only do something if the project uses version catalogs to define the imported
BOMs (via `boms-` prefix).

This will make it less likely to write faulty BOMs like discovered in
micronaut-projects/micronaut-aws#1216

To give you an example, this is what the AWS bom module looked like, and it was buggy (wrong modules included, wrong versions, ...)

```gradle
plugins {
    id 'java-platform'
    id 'io.micronaut.build.internal.publishing'
    id 'io.micronaut.build.internal.dependency-updates'
}
version projectVersion
group "io.micronaut.aws"
javaPlatform {
    allowDependencies()
}
dependencies {
    constraints {
        for (Project p : rootProject.subprojects) {
            if (p.name.endsWith("-bom")) {
                continue
            }
            api "$p.group:micronaut-$p.name:$p.version"
        }
    }
}
```


Now it's reduced to this, will additional benefits (sanity checks, catalog, ...)
```gradle
plugins {
    id 'io.micronaut.build.internal.bom'
}

version projectVersion
group "io.micronaut.aws"

```

The Micronaut Core BOM project would be drastically reduced too:

```gradle
plugins {
    id 'io.micronaut.build.internal.bom'
}

group projectGroupId
version projectVersion

micronautBom {
    extraExcludedProjects = [
            "benchmarks",
            "inject-test-utils"
    ]
    catalogToPropertyNameOverrides = [
            'jakarta.annotation.api': 'jakarta.annotation-api',
            'javax.annotation.api': 'javax.annotation-api',
            'methvin.directory.watcher': 'methvin.directory-watcher',
            'paho.v3': 'pahov3',
            'paho.v5': 'pahov5',
            'graal.sdk': 'graalSdk',
            'neo4j.java.driver': 'neo4j.bolt',
    ]
}
```