### PR TITLE
Fix position of classifier in gradle dependencies

### DIFF
--- a/src/main/groovy/io/micronaut/docs/BuildDependencyMacro.groovy
+++ b/src/main/groovy/io/micronaut/docs/BuildDependencyMacro.groovy
@@ -155,8 +155,11 @@ class BuildDependencyMacro extends InlineMacroProcessor implements ValueAtAttrib
 <pre class=\"highlightjs highlight\"><code class=\"language-kotlin hljs" data-lang="${build}">"""
 
         html += "${scope}(<span class=\"hljs-string\">\"${groupId}:${artifactId}"
+        if (version || classifier) {
+            html += ":"
+        }
         if (version) {
-            html += ":${version}"
+            html += "${version}"
         }
         if (classifier) {
             html += ":${classifier}"

--- a/src/test/groovy/io/micronaut/docs/BuildDependencyMacroSpec.groovy
+++ b/src/test/groovy/io/micronaut/docs/BuildDependencyMacroSpec.groovy
@@ -18,4 +18,29 @@ class BuildDependencyMacroSpec extends Specification {
         and: 'snippet is kotlin compatible. It contains parenthesis and double quotes'
         content.contains('implementation(<span class="hljs-string">"io.micronaut:micronaut-function-aws-alexa")')
     }
+
+    void "version appears after the 2nd column for gradle"() {
+        when:
+        def content = BuildDependencyMacro.contentForTargetAndAttributes("artifactId", ["text": 'version="1.2.3"'])
+
+        then:
+        content.contains('io.micronaut:artifactId:1.2.3')
+    }
+
+    void "classifier appears after the 3rd column for gradle"() {
+        when:
+        def content = BuildDependencyMacro.contentForTargetAndAttributes("artifactId", ["text": 'classifier="ARCH"'])
+
+        then:
+        !content.contains('io.micronaut:artifactId:ARCH')
+        content.contains('io.micronaut:artifactId::ARCH')
+    }
+
+    void "paired version and classifier appear after the 2nd and 3rd column respectively for gradle"() {
+        when:
+        def content = BuildDependencyMacro.contentForTargetAndAttributes("artifactId", ["text": 'version="1.2.3",classifier="ARCH"'])
+
+        then:
+        content.contains('io.micronaut:artifactId:1.2.3:ARCH')
+    }
 }


### PR DESCRIPTION
This is to fix a few misleading declarations in Micronaut's Guide, s.a.:
`runtime("io.netty:netty-transport-native-epoll:linux-x86_64")`
... which makes gradle handle `linux-x86_64` as a *version* instead of a *classifier*:
> Resource missing. [HTTP GET: https://jcenter.bintray.com/io/netty/netty-transport-native-epoll/linux-x86_64/netty-transport-native-epoll-linux-x86_64.pom]

The above should indeed be spelled:
`runtime("io.netty:netty-transport-native-epoll::linux-x86_64")`
(the actual version comes through Micronaut's BOM).