### PR TITLE
Introduce AOT module plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ gradlePlugin.testSourceSets(sourceSets.functionalTest)
 configurations.functionalTestImplementation.extendsFrom(configurations.testImplementation)
 
 tasks.register('functionalTest', Test) {
+    inputs.dir(file("src/functionalTest/gradle-projects"))
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
     useJUnitPlatform()
@@ -152,6 +153,10 @@ gradlePlugin {
         sharedSettings {
             id = 'io.micronaut.build.shared.settings'
             implementationClass = 'io.micronaut.build.MicronautSharedSettingsPlugin'
+        }
+        aotModule {
+            id = 'io.micronaut.build.internal.aot-module'
+            implementationClass = 'io.micronaut.build.aot.MicronautAotModulePlugin'
         }
     }
 }

--- a/src/functionalTest/gradle-projects/test-aot-module/build.gradle
+++ b/src/functionalTest/gradle-projects/test-aot-module/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+	id 'io.micronaut.build.internal.aot-module'
+}
+
+group = 'io.micronaut.dummy'
+
+repositories {
+	mavenCentral()
+}
+
+micronautBuild {
+	aot {
+		version = "1.0.0-M2"
+	}
+}

--- a/src/functionalTest/gradle-projects/test-aot-module/gradle.properties
+++ b/src/functionalTest/gradle-projects/test-aot-module/gradle.properties
@@ -1,0 +1,21 @@
+projectVersion=1.0.0-SNAPSHOT
+micronautDocsVersion=2.0.0.RC1
+micronautVersion=3.2.0
+micronautTestVersion=2.3.7
+groovyVersion=3.0.8
+spockVersion=2.0-groovy-3.0
+
+title=Micronaut AOT test module
+projectDesc=Build time optimizations for Micronaut
+projectUrl=https://micronaut.io
+githubSlug=micronaut-projects/micronaut-aot-test-module
+developers=Graeme Rocher
+
+# Micronaut core branch for BOM pull requests
+githubCoreBranch=3.2.x
+
+bomProperty=micronautAotVersion
+
+org.gradle.caching=true
+org.gradle.parallel=true
+

--- a/src/functionalTest/gradle-projects/test-aot-module/settings.gradle
+++ b/src/functionalTest/gradle-projects/test-aot-module/settings.gradle
@@ -1,0 +1,5 @@
+plugins {
+    id("io.micronaut.build.shared.settings")
+}
+
+rootProject.name = 'test-aot-module'

--- a/src/functionalTest/gradle-projects/test-aot-module/src/main/java/io/micronaut/myaot/MyAot.java
+++ b/src/functionalTest/gradle-projects/test-aot-module/src/main/java/io/micronaut/myaot/MyAot.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.myaot;
+
+import com.squareup.javapoet.MethodSpec;
+import io.micronaut.aot.core.AOTContext;
+import io.micronaut.aot.core.AOTModule;
+import io.micronaut.aot.core.codegen.AbstractCodeGenerator;
+
+import javax.lang.model.element.Modifier;
+
+import static io.micronaut.myaot.MyAot.DESCRIPTION;
+import static io.micronaut.myaot.MyAot.ID;
+
+@AOTModule(
+        id = ID,
+        description = DESCRIPTION
+)
+public class MyAot extends AbstractCodeGenerator {
+    public static final String ID = "myaot";
+    public static final String DESCRIPTION = "My AOT module";
+
+    @Override
+    public void generate(AOTContext context) {
+        context.registerStaticInitializer(
+                MethodSpec.methodBuilder("foo")
+                        .addModifiers(Modifier.PUBLIC)
+                        .addStatement("System.out.println(\"Hello World\")")
+                        .build());
+    }
+}

--- a/src/functionalTest/gradle-projects/test-aot-module/src/main/resources/META-INF/services/io.micronaut.aot.core.AOTCodeGenerator
+++ b/src/functionalTest/gradle-projects/test-aot-module/src/main/resources/META-INF/services/io.micronaut.aot.core.AOTCodeGenerator
@@ -1,0 +1,1 @@
+io.micronaut.myaot.MyAot

--- a/src/functionalTest/gradle-projects/test-aot-module/src/test/groovy/io/micronaut/myaot/MyAotSpec.groovy
+++ b/src/functionalTest/gradle-projects/test-aot-module/src/test/groovy/io/micronaut/myaot/MyAotSpec.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.myaot
+
+import io.micronaut.aot.core.AOTCodeGenerator
+import io.micronaut.aot.core.codegen.AbstractSourceGeneratorSpec
+
+class MyAotSpec extends AbstractSourceGeneratorSpec {
+    @Override
+    AOTCodeGenerator newGenerator() {
+        new MyAot()
+    }
+
+    def "tests AOT module"() {
+        when:
+        generate()
+
+        then:
+        assertThatGeneratedSources {
+            createsInitializer 'public void foo() {\n  System.out.println("Hello World");\n}'
+            doesNotGenerateClasses()
+        }
+    }
+}

--- a/src/functionalTest/groovy/io/micronaut/build/AbstractFunctionalTest.groovy
+++ b/src/functionalTest/groovy/io/micronaut/build/AbstractFunctionalTest.groovy
@@ -18,6 +18,7 @@ package io.micronaut.build
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.GFileUtils
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -44,6 +45,10 @@ abstract class AbstractFunctionalTest extends Specification {
         fileRef
     }
 
+    File getGradlePropertiesFile() {
+        return file("gradle.properties")
+    }
+
     File getGroovyBuildFile() {
         file("build.gradle")
     }
@@ -66,6 +71,11 @@ abstract class AbstractFunctionalTest extends Specification {
 
     File getSettingsFile() {
         groovySettingsFile
+    }
+
+    protected void withSample(String name) {
+        File sampleDir = new File("src/functionalTest/gradle-projects/$name")
+        GFileUtils.copyDirectory(sampleDir, testDirectory.toFile())
     }
 
     void run(String... args) {
@@ -123,6 +133,7 @@ abstract class AbstractFunctionalTest extends Specification {
     private ArrayList<String> computeAutoArgs() {
         List<String> autoArgs = [
                 "-S",
+                "--no-build-cache"
         ]
         if (Boolean.getBoolean("config.cache")) {
             autoArgs << '--configuration-cache'

--- a/src/functionalTest/groovy/io/micronaut/build/aot/AOTModuleFunctionalTest.groovy
+++ b/src/functionalTest/groovy/io/micronaut/build/aot/AOTModuleFunctionalTest.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.build.aot
+
+import io.micronaut.build.AbstractFunctionalTest
+
+class AOTModuleFunctionalTest extends AbstractFunctionalTest {
+    def "can create an AOT module"() {
+        given:
+        withSample("test-aot-module")
+
+        when:
+        run 'test'
+
+        then:
+        tasks {
+            succeeded ':compileJava'
+            succeeded ':compileTestGroovy'
+            succeeded ':test'
+        }
+
+    }
+}

--- a/src/main/groovy/io/micronaut/build/aot/MicronautAotModulePlugin.java
+++ b/src/main/groovy/io/micronaut/build/aot/MicronautAotModulePlugin.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.aot;
+
+import io.micronaut.build.MicronautBaseModulePlugin;
+import io.micronaut.build.MicronautBuildExtension;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.JavaPlugin;
+
+/**
+ * This plugin is used to implement a Micronaut AOT extension,
+ * e.g. an AOT code generator.
+ */
+public class MicronautAotModulePlugin implements Plugin<Project> {
+    private static final String DEFAULT_AOT_VERSION = "1.0.0";
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(MicronautBaseModulePlugin.class);
+        MicronautBuildExtension micronautBuildExtension = project.getExtensions().getByType(MicronautBuildExtension.class);
+        // An AOT module MUST NOT use Micronaut DI
+        micronautBuildExtension.setEnableBom(false);
+        micronautBuildExtension.setEnableProcessing(false);
+        MicronautBuildAotExtension aotExtension = ((ExtensionAware) micronautBuildExtension).getExtensions().create("aot", MicronautBuildAotExtension.class);
+        aotExtension.getVersion().convention(DEFAULT_AOT_VERSION);
+        String micronautVersion = String.valueOf(project.getProperties().get("micronautVersion"));
+        DependencyHandler deps = project.getDependencies();
+        deps.addProvider(JavaPlugin.COMPILE_ONLY_API_CONFIGURATION_NAME, aotExtension.getVersion().map(version -> aotModule("core", version)));
+        deps.add(JavaPlugin.COMPILE_ONLY_API_CONFIGURATION_NAME, coreModule("context", micronautVersion));
+        deps.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, coreModule("context", micronautVersion));
+        deps.addProvider(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, aotExtension.getVersion().map(version -> {
+            String aot = aotModule("core", version);
+            ExternalModuleDependency dependency = (ExternalModuleDependency) deps.create(aot);
+            dependency.capabilities(capabilities -> capabilities.requireCapability("io.micronaut.aot:aot-core-test-fixtures"));
+            return dependency;
+        }));
+    }
+
+    private static String aotModule(String name, String version) {
+        return "io.micronaut.aot:micronaut-aot-" + name + ":" + version;
+    }
+
+    private static String coreModule(String name, String version) {
+        return "io.micronaut:micronaut-" + name + ":" + version;
+    }
+}

--- a/src/main/java/io/micronaut/build/aot/MicronautBuildAotExtension.java
+++ b/src/main/java/io/micronaut/build/aot/MicronautBuildAotExtension.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.aot;
+
+import org.gradle.api.provider.Property;
+
+/**
+ * The extension used to configure the AOT plugin.
+ */
+public interface MicronautBuildAotExtension {
+    /**
+     * The Micronaut AOT version to target.
+     * @return the version property
+     */
+    Property<String> getVersion();
+}


### PR DESCRIPTION
This plugin makes it possible to build Micronaut AOT modules. A
Micronaut AOT module isn't a traditional Micronaut module: it will
not use injection, and needs to use a specific API. The plugin is
responsible for setting up the project in the correct way, and it
will automatically add the test fixtures from AOT.

This means that in a particular Micronaut repository, it is possible
to have a module which is an extension to AOT. The user would then
have to integrate the AOT module to the AOT classpath (via the Gradle
plugin for now) to benefit from the optimizations.