### PR TITLE
Fix how aggregated javadocs are produced

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBasePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBasePlugin.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.build
 
 import groovy.transform.CompileStatic
+import io.micronaut.build.docs.AggregatedJavadocParticipantPlugin
 import io.micronaut.build.docs.ConfigurationPropertiesPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -35,6 +36,7 @@ class MicronautBasePlugin implements Plugin<Project> {
         configureProjectVersion(project)
         project.pluginManager.apply(MicronautBuildExtensionPlugin)
         project.pluginManager.apply(ConfigurationPropertiesPlugin)
+        project.pluginManager.apply(AggregatedJavadocParticipantPlugin)
     }
 
     private void configureProjectVersion(Project project) {

--- a/src/main/groovy/io/micronaut/build/docs/AggregatedJavadocParticipantPlugin.java
+++ b/src/main/groovy/io/micronaut/build/docs/AggregatedJavadocParticipantPlugin.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.docs;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.javadoc.Javadoc;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A plugin which marks a project as a participant
+ * in the aggregated javadoc generation. The aggregator
+ * will need information about the javadoc classpath,
+ * includes and excludes.
+ */
+public class AggregatedJavadocParticipantPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().withPlugin("java", unused -> {
+            Configuration internalJavadocElements = createFilteredJavadocSourcesElements(project);
+            Configuration javadocElementClasspath = createJavadocElementClasspath(project);
+            TaskProvider<PrepareJavadocAggregationTask> prepareTask = project.getTasks().register("prepareJavadocAggregation", PrepareJavadocAggregationTask.class, task -> {
+                Javadoc javadoc = project.getTasks().named("javadoc", Javadoc.class).get();
+                JavaPluginConvention javaPluginConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
+                SourceSet sourceSet = javaPluginConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+                task.getSources().from(sourceSet.getAllJava().getSourceDirectories());
+                task.getIncludes().set(javadoc.getIncludes());
+                task.getExcludes().set(javadoc.getExcludes());
+                task.getOutputDir().set(project.getLayout().getBuildDirectory().dir("aggregation/javadoc"));
+            });
+            internalJavadocElements.getOutgoing().artifact(prepareTask);
+        });
+    }
+
+    private Configuration createJavadocElementClasspath(Project project) {
+        ConfigurationContainer configurations = project.getConfigurations();
+        return configurations.create("internalJavadocClasspathElements", conf -> {
+            conf.setCanBeResolved(false);
+            conf.setCanBeConsumed(true);
+            Configuration compileClasspath = configurations.getByName("compileClasspath");
+            AttributeContainer compileClasspathAttrs = compileClasspath.getAttributes();
+            conf.extendsFrom(compileClasspath);
+            conf.attributes(attrs -> compileClasspathAttrs.keySet().forEach(key -> {
+                Object attribute = compileClasspathAttrs.getAttribute(key);
+                //noinspection unchecked
+                attrs.attribute((Attribute<Object>)key, attribute);
+                attrs.attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, JavadocAggregationUtils.AGGREGATED_JAVADOC_PARTICIPANT_DEPS));
+            }));
+        });
+    }
+
+    @NotNull
+    private Configuration createFilteredJavadocSourcesElements(Project project) {
+        return project.getConfigurations().create("internalJavadocElements", conf -> {
+            conf.setCanBeConsumed(true);
+            conf.setCanBeResolved(false);
+            ObjectFactory objects = project.getObjects();
+            JavadocAggregationUtils.configureJavadocSourcesAggregationAttributes(objects, conf);
+        });
+    }
+}

--- a/src/main/groovy/io/micronaut/build/docs/JavadocAggregationUtils.java
+++ b/src/main/groovy/io/micronaut/build/docs/JavadocAggregationUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.docs;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.model.ObjectFactory;
+
+abstract class JavadocAggregationUtils {
+    public static final String AGGREGATED_JAVADOC_PARTICIPANT_SOURCES = "aggregatedJavadocParticipantSources";
+    public static final String AGGREGATED_JAVADOC_PARTICIPANT_DEPS = "aggregatedJavadocParticipantDependencies";
+
+    static void configureJavadocSourcesAggregationAttributes(ObjectFactory objects, Configuration conf) {
+        conf.attributes(attrs -> {
+            attrs.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, AGGREGATED_JAVADOC_PARTICIPANT_SOURCES));
+            attrs.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.DOCUMENTATION));
+        });
+    }
+
+}

--- a/src/main/groovy/io/micronaut/build/docs/JavadocAggregatorPlugin.java
+++ b/src/main/groovy/io/micronaut/build/docs/JavadocAggregatorPlugin.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.docs;
+
+import io.micronaut.build.MicronautBuildExtension;
+import io.micronaut.build.MicronautBuildExtensionPlugin;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.AttributeCompatibilityRule;
+import org.gradle.api.attributes.Bundling;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.CompatibilityCheckDetails;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.javadoc.Javadoc;
+import org.gradle.external.javadoc.StandardJavadocDocletOptions;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+
+import java.util.Map;
+
+@CacheableTask
+public abstract class JavadocAggregatorPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        // todo: replace with a narrower plugin once
+        //  https://github.com/gradle/gradle/issues/19234 is fixed.
+        project.getPluginManager().apply(JavaBasePlugin.class);
+        project.getPluginManager().apply(MicronautBuildExtensionPlugin.class);
+        MicronautBuildExtension micronautBuildExtension = project.getExtensions().getByType(MicronautBuildExtension.class);
+        project.getDependencies().getAttributesSchema().attribute(Usage.USAGE_ATTRIBUTE).getCompatibilityRules().add(ApiCompatibilityRule.class);
+        Configuration javadocAggregatorBase = createAggregationConfigurationBase(project);
+        Configuration javadocAggregator = createAggregationConfiguration(project, javadocAggregatorBase);
+        Configuration javadocAggregatorClasspath = createAggregationConfigurationClasspath(project, javadocAggregatorBase);
+        project.getSubprojects().forEach(subproject -> {
+            subproject.getPlugins().withType(AggregatedJavadocParticipantPlugin.class, plugin -> {
+                project.evaluationDependsOn(subproject.getPath());
+                javadocAggregatorBase.getDependencies().add(
+                        project.getDependencies().create(subproject)
+                );
+            });
+        });
+        JavaToolchainService toolchains = project.getExtensions().getByType(JavaToolchainService.class);
+        project.getTasks().register("javadoc", Javadoc.class, javadoc -> {
+            javadoc.setDescription("Generate javadocs from all child projects as if it was a single project");
+            javadoc.setGroup("Documentation");
+
+            javadoc.setDestinationDir(project.getLayout().getBuildDirectory().dir("working/00-api").get().getAsFile());
+            javadoc.setTitle(project.getName() + " " + project.getVersion() + " API");
+            StandardJavadocDocletOptions options = (StandardJavadocDocletOptions) javadoc.getOptions();
+            options.author(true);
+            javadoc.exclude("example/**");
+            // Use Java Toolchain to render consistent javadocs
+            javadoc.getJavadocTool().convention(toolchains.javadocToolFor(spec -> spec.getLanguageVersion().set(asLanguageVersion(micronautBuildExtension))));
+            options.setSource(micronautBuildExtension.getSourceCompatibility());
+            options.links(project.getProperties()
+                    .entrySet()
+                    .stream()
+                    .filter(entry -> entry.getKey().endsWith("api"))
+                    .map(Map.Entry::getValue)
+                    .map(String::valueOf)
+                    .filter(link -> link.startsWith("http")).toArray(String[]::new));
+            options.addStringOption("Xdoclint:none", "-quiet");
+            options.addBooleanOption("notimestamp", true);
+            javadoc.setSource(javadocAggregator);
+            javadoc.setClasspath(javadocAggregatorClasspath);
+        });
+    }
+
+    private static JavaLanguageVersion asLanguageVersion(MicronautBuildExtension micronautBuildExtension) {
+        String sourceCompatibility = micronautBuildExtension.getSourceCompatibility();
+        if (sourceCompatibility.startsWith("1.")) {
+            sourceCompatibility = sourceCompatibility.substring(2);
+        }
+        return JavaLanguageVersion.of(sourceCompatibility);
+    }
+
+    private Configuration createAggregationConfiguration(Project project, Configuration javadocAggregatorBase) {
+        return project.getConfigurations().create("javadocAggregator", conf -> {
+            conf.setCanBeConsumed(false);
+            conf.setCanBeResolved(true);
+            conf.extendsFrom(javadocAggregatorBase);
+            JavadocAggregationUtils.configureJavadocSourcesAggregationAttributes(project.getObjects(), conf);
+        });
+    }
+
+    private Configuration createAggregationConfigurationClasspath(Project project, Configuration javadocAggregatorBase) {
+        return project.getConfigurations().create("javadocAggregatorClasspath", conf -> {
+            conf.setCanBeConsumed(false);
+            conf.setCanBeResolved(true);
+            conf.extendsFrom(javadocAggregatorBase);
+            conf.attributes(attrs -> {
+                attrs.attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, JavadocAggregationUtils.AGGREGATED_JAVADOC_PARTICIPANT_DEPS));
+                attrs.attribute(Category.CATEGORY_ATTRIBUTE, project.getObjects().named(Category.class, Category.LIBRARY));
+                attrs.attribute(Bundling.BUNDLING_ATTRIBUTE, project.getObjects().named(Bundling.class, Bundling.EXTERNAL));
+            });
+        });
+    }
+
+    private Configuration createAggregationConfigurationBase(Project project) {
+        return project.getConfigurations().create("javadocAggregatorBase", conf -> {
+            conf.setCanBeConsumed(false);
+            conf.setCanBeResolved(false);
+        });
+    }
+
+    public static class ApiCompatibilityRule implements AttributeCompatibilityRule<Usage> {
+        @Override
+        public void execute(CompatibilityCheckDetails<Usage> details) {
+            Usage consumerValue = details.getConsumerValue();
+            if (consumerValue != null && consumerValue.getName().equals(JavadocAggregationUtils.AGGREGATED_JAVADOC_PARTICIPANT_DEPS)) {
+                Usage producerValue = details.getProducerValue();
+                if (producerValue != null && producerValue.getName().equals(Usage.JAVA_API)) {
+                    details.compatible();
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/io/micronaut/build/docs/PrepareJavadocAggregationTask.java
+++ b/src/main/groovy/io/micronaut/build/docs/PrepareJavadocAggregationTask.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.docs;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+@CacheableTask
+public abstract class PrepareJavadocAggregationTask extends DefaultTask {
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getSources();
+
+    @Input
+    public abstract SetProperty<String> getIncludes();
+
+    @Input
+    public abstract SetProperty<String> getExcludes();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDir();
+
+    @Inject
+    public abstract FileOperations getFileOperations();
+
+    @TaskAction
+    public void prepareJavadocAggregation() {
+        getFileOperations().sync(spec -> {
+            spec.from(getSources(), file -> {
+                Set<String> excludes = getExcludes().get();
+                if (!excludes.isEmpty()) {
+                    file.exclude(excludes);
+                }
+                Set<String> includes = getIncludes().get();
+                if (!includes.isEmpty()) {
+                    file.include(includes);
+                }
+            });
+            spec.exclude(f -> f.getFile().isFile() && !f.getName().endsWith(".java"));
+            spec.into(getOutputDir().getAsFile());
+        });
+    }
+
+}


### PR DESCRIPTION
Before this commit, Javadoc aggregation was generated by accessing other
project's state directly. While being much simpler to write, this was
causing deprecation warnings in the build, regarding configurations
being resolved out of context.

The fix wasn't trivial to implement, because we need a generic fix
which supports includes and excludes. Therefore, the way the aggregation
works is now by applying a couple of plugins:

- on a module which needs to be aggregated, we apply a plugin which is
responsible for setting up a couple of outgoing configurations: one
for the _sources_ which need to participate in javadocs, and another
one with the _classpath_. This is `AggregatedJavadocParticipantPlugin`
- on the aggregating project, we also need a couple of configurations
which are this time resolved, for the sources and classpath, but we
also need a disambiguation rule for the aggregated classpath, so that
there's no ambiguity between the compile classpath and the javadoc
"compile" classpath.

This also means that this process is also slower, since we need
to produce an artifact on the aggregated projects which is the sources
with the include/exclude filters applied, instead of getting a "view"
of the existing sources, which would be sufficient. Currently this
is implemented as a "sync" copy (not a zip).