### PR TITLE
Always generate test reports

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -112,9 +112,6 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
             jvmArgs '-Duser.country=US'
             jvmArgs '-Duser.language=en'
 
-            reports.html.required = micronautBuildExtension.environment.isNotGithubAction()
-            reports.junitXml.required = true
-
             String groovyVersion = project.findProperty("groovyVersion")
             if (groovyVersion?.startsWith("3")) {
                 useJUnitPlatform()


### PR DESCRIPTION
As discussed with the Gradle team, generating reports is pretty cheap.
By having a different strategy to generate reports on CI and locally,
this prevents reusing build cache entries.