### PR TITLE
Enable forked compilation by default

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -129,12 +129,19 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
             groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
         }
 
-        project.tasks.withType(JavaCompile).configureEach {
-            options.encoding = "UTF-8"
-            options.compilerArgs.add('-parameters')
-            if (micronautBuildExtension.enableProcessing) {
-                options.compilerArgs.add("-Amicronaut.processing.group=$project.group")
-                options.compilerArgs.add("-Amicronaut.processing.module=micronaut-$project.name")
+        project.afterEvaluate {
+            def compileOptions = micronautBuildExtension.compileOptions
+            project.tasks.withType(JavaCompile).configureEach {
+                    options.encoding = "UTF-8"
+                    options.compilerArgs.add('-parameters')
+                    if (micronautBuildExtension.enableProcessing) {
+                        options.compilerArgs.add("-Amicronaut.processing.group=$project.group")
+                        options.compilerArgs.add("-Amicronaut.processing.module=micronaut-$project.name")
+                    }
+                compileOptions.applyTo(options)
+            }
+            project.tasks.withType(GroovyCompile).configureEach {
+                compileOptions.applyTo(options)
             }
         }
 

--- a/src/main/groovy/io/micronaut/build/MicronautBuildExtension.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildExtension.groovy
@@ -1,15 +1,25 @@
 package io.micronaut.build
 
 import org.gradle.api.artifacts.ResolutionStrategy
+import org.gradle.api.model.ObjectFactory
 
 import javax.inject.Inject
 
-class MicronautBuildExtension {
+abstract class MicronautBuildExtension {
     private final BuildEnvironment environment
+    private final MicronautCompileOptions compileOptions
+
+    MicronautCompileOptions getCompileOptions() {
+        compileOptions
+    }
+
+    @Inject
+    abstract ObjectFactory getObjects()
 
     @Inject
     MicronautBuildExtension(BuildEnvironment buildEnvironment) {
         this.environment = buildEnvironment
+        this.compileOptions = getObjects().newInstance(MicronautCompileOptions)
     }
 
     /**

--- a/src/main/java/io/micronaut/build/MicronautCompileOptions.java
+++ b/src/main/java/io/micronaut/build/MicronautCompileOptions.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.compile.CompileOptions;
+
+import javax.inject.Inject;
+
+public abstract class MicronautCompileOptions {
+    public abstract Property<Boolean> getFork();
+    public abstract Property<String> getMaxMemory();
+
+    @Inject
+    public MicronautCompileOptions() {
+        getFork().convention(true);
+        getMaxMemory().convention("1048m");
+    }
+
+    void applyTo(CompileOptions compileOptions) {
+        if (getFork().get()) {
+            compileOptions.setFork(true);
+            compileOptions.getForkOptions().setMemoryMaximumSize(getMaxMemory().get());
+        }
+    }
+}


### PR DESCRIPTION
This commit enables _forked compilation_, which seems to improve
stability of builds, especially when changing annotation processors.

It is possible, on a per-project basis, to disable forked compilation
or change the default maximum memory per forked process.