### PR TITLE
Fix useLatestVersions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation "com.diffplug.spotless:spotless-plugin-gradle:5.14.2"
     implementation "com.adarshr:gradle-test-logger-plugin:3.0.0"
     implementation "io.github.gradle-nexus:publish-plugin:1.1.0"
-    implementation "se.patrikerdes:gradle-use-latest-versions-plugin:0.2.16"
+    implementation "se.patrikerdes:gradle-use-latest-versions-plugin:0.2.18"
     implementation('com.lowagie:itext:2.0.8')
     implementation 'org.jsoup:jsoup:1.14.2'
     implementation('org.xhtmlrenderer:core-renderer:8.0') {

--- a/src/main/groovy/io/micronaut/build/MicronautDependencyUpdatesPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautDependencyUpdatesPlugin.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.build
 
+import io.micronaut.build.catalogs.MicronautVersionCatalogUpdatePlugin
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -18,6 +19,12 @@ class MicronautDependencyUpdatesPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         project.pluginManager.apply(MicronautBuildExtensionPlugin)
+        if (project.rootProject.file("gradle/libs.versions.toml").exists()) {
+            if (project == project.rootProject) {
+                project.pluginManager.apply(MicronautVersionCatalogUpdatePlugin)
+            }
+            return
+        }
         project.apply plugin: GRADLE_VERSIONS_PLUGIN
         project.apply plugin: USE_LATEST_VERSIONS_PLUGIN
 
@@ -32,7 +39,7 @@ class MicronautDependencyUpdatesPlugin implements Plugin<Project> {
         project.with {
             tasks.named("dependencyUpdates") {
                 onlyIf {
-                    gradle.taskGraph.hasTask("useLatestVersions")
+                    gradle.taskGraph.hasTask(":useLatestVersions")
                 }
                 checkForGradleUpdate = true
                 gradleReleaseChannel = "current"


### PR DESCRIPTION
This commit fixes the "useLatestVersions" task which was broken in 2 cases:

- for most projects, it wouldn't run the `dependencyUpdates` task prior to execution
- for projects using version catalogs, the version catalog update plugin should be used instead
- 