### PR TITLE
Add binary compatibility checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     implementation 'org.nosphere.gradle.github:gradle-github-actions-plugin:1.3.2'
     implementation 'com.gradle:common-custom-user-data-gradle-plugin:1.6.3'
     implementation 'org.gradle:test-retry-gradle-plugin:1.3.1'
-    implementation 'me.champeau.gradle:japicmp-gradle-plugin:0.3.1'
+    implementation 'me.champeau.gradle:japicmp-gradle-plugin:0.4.0'
 
     implementation 'org.tomlj:tomlj:1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     implementation 'org.nosphere.gradle.github:gradle-github-actions-plugin:1.3.2'
     implementation 'com.gradle:common-custom-user-data-gradle-plugin:1.6.3'
     implementation 'org.gradle:test-retry-gradle-plugin:1.3.1'
+    implementation 'me.champeau.gradle:japicmp-gradle-plugin:0.3.1'
 
     implementation 'org.tomlj:tomlj:1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,10 @@ gradlePlugin {
             id = 'io.micronaut.build.internal.quality-checks'
             implementationClass = 'io.micronaut.build.MicronautQualityChecksParticipantPlugin'
         }
-
+        binaryCompatibilityCheck {
+            id = 'io.micronaut.build.internal.binary-compatibility-check'
+            implementationClass = 'io.micronaut.build.compat.MicronautBinaryCompatibilityPlugin'
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=5.2.3-SNAPSHOT
+projectVersion=5.3.0-SNAPSHOT
 title=Micronaut Build Plugins
 projectDesc=Micronaut internal Gradle plugins. Not intended to be used in user's projects
 projectUrl=https://micronaut.io

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'micronaut-build'
+
+includeBuild "/home/cchampeau/DEV/PROJECTS/GITHUB/japicmp-gradle-plugin"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,1 @@
 rootProject.name = 'micronaut-build'
-
-includeBuild "/home/cchampeau/DEV/PROJECTS/GITHUB/japicmp-gradle-plugin"

--- a/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.build
 
 import groovy.transform.CompileStatic
+import io.micronaut.build.compat.MicronautBinaryCompatibilityPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.internal.GradleInternal
@@ -23,6 +24,7 @@ class MicronautBaseModulePlugin implements Plugin<Project> {
         project.pluginManager.apply(MicronautBuildCommonPlugin)
         project.pluginManager.apply(MicronautDependencyUpdatesPlugin)
         project.pluginManager.apply(MicronautPublishingPlugin)
+        project.pluginManager.apply(MicronautBinaryCompatibilityPlugin)
         configureJUnit(project)
         assertSettingsPluginApplied(project)
     }

--- a/src/main/groovy/io/micronaut/build/compat/AcceptanceHelper.groovy
+++ b/src/main/groovy/io/micronaut/build/compat/AcceptanceHelper.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.build.compat
+
+class AcceptanceHelper {
+    static String formatAcceptance(String type, String member ) {
+        String json = """{
+    "type": "$type",
+    "member": "$member",
+    "reason": "Provide a human readable reason for the change"
+}"""
+        def changeId = (type + member).replaceAll('[^a-zA-Z0-9]', '_')
+        """.
+                <br>
+                <p>
+                If you did this intentionally, please accept the change and provide an explanation:
+                <a class="btn btn-info" role="button" data-toggle="collapse" href="#accept-${changeId}" aria-expanded="false" aria-controls="collapseExample">Accept this change</a>
+                <div class="collapse" id="accept-${changeId}">
+                  <div class="well">
+                      In order to accept this change add the following to <code>accepted-api-changes.json</code>:
+                    <pre>$json</pre>
+                  </div>
+                </div>
+                </p>""".stripIndent()
+    }
+}

--- a/src/main/groovy/io/micronaut/build/compat/AcceptedApiChange.java
+++ b/src/main/groovy/io/micronaut/build/compat/AcceptedApiChange.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.compat;
+
+import java.io.Serializable;
+
+public class AcceptedApiChange implements Serializable {
+    private final String type;
+    private final String member;
+    private final String reason;
+
+    public AcceptedApiChange(String type, String member, String reason) {
+        this.type = type;
+        this.member = member;
+        this.reason = reason;
+    }
+
+    public boolean matches(String type, String member) {
+        return this.type.equals(type) && this.member.equals(member);
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getMember() {
+        return member;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/src/main/groovy/io/micronaut/build/compat/AcceptedApiChangesParser.groovy
+++ b/src/main/groovy/io/micronaut/build/compat/AcceptedApiChangesParser.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.build.compat
+
+import groovy.json.JsonSlurper
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class AcceptedApiChangesParser {
+    static List<AcceptedApiChange> parse(InputStream jsonStream) {
+        def parser = new JsonSlurper()
+        List<Map<String, String>> json = parser.parse(jsonStream) as List<Map<String, String>>
+        return json.collect {map ->
+            new AcceptedApiChange(
+                    map["type"],
+                    map["member"],
+                    map["reason"]
+            )
+        }
+    }
+}

--- a/src/main/groovy/io/micronaut/build/compat/AcceptedApiChangesRule.java
+++ b/src/main/groovy/io/micronaut/build/compat/AcceptedApiChangesRule.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.compat;
+
+import me.champeau.gradle.japicmp.report.Violation;
+import me.champeau.gradle.japicmp.report.ViolationTransformer;
+import org.gradle.api.GradleException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static io.micronaut.build.compat.AcceptanceHelper.formatAcceptance;
+
+public class AcceptedApiChangesRule implements ViolationTransformer {
+    public static final String CHANGES_FILE = "changesFile";
+
+    private final Map<String, List<AcceptedApiChange>> changes;
+
+    public AcceptedApiChangesRule(Map<String, String> params) {
+        String filePath = params.get(CHANGES_FILE);
+        File changesFile = new File(filePath);
+        if (changesFile.exists()) {
+            try (FileInputStream fis = new FileInputStream(filePath)) {
+                this.changes = AcceptedApiChangesParser.parse(fis)
+                        .stream()
+                        .collect(Collectors.groupingBy(AcceptedApiChange::getType));
+            } catch (IOException e) {
+                throw new GradleException("Unable to parse accepted regressions file", e);
+            }
+        } else {
+            this.changes = Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public Optional<Violation> transform(String type, Violation violation) {
+        List<AcceptedApiChange> apiChanges = changes.get(type);
+        String violationDescription = Violation.describe(violation.getMember());
+        if (apiChanges != null) {
+            Optional<AcceptedApiChange> any = apiChanges.stream()
+                    .filter(c -> c.matches(type, violationDescription))
+                    .findAny();
+            if (any.isPresent()) {
+                return Optional.of(violation.acceptWithDescription(any.get().getReason()));
+            }
+        }
+        switch (violation.getSeverity()) {
+            case info:
+            case accepted:
+                return Optional.of(violation);
+            default:
+                return Optional.of(violation.withDescription(
+                    violation.getHumanExplanation() + formatAcceptance(type, violationDescription))
+            );
+        }
+    }
+}

--- a/src/main/groovy/io/micronaut/build/compat/AcceptedApiChangesRule.java
+++ b/src/main/groovy/io/micronaut/build/compat/AcceptedApiChangesRule.java
@@ -66,6 +66,7 @@ public class AcceptedApiChangesRule implements ViolationTransformer {
         switch (violation.getSeverity()) {
             case info:
             case accepted:
+            case warning:
                 return Optional.of(violation);
             default:
                 return Optional.of(violation.withDescription(

--- a/src/main/groovy/io/micronaut/build/compat/BinaryCompatibibilityExtension.java
+++ b/src/main/groovy/io/micronaut/build/compat/BinaryCompatibibilityExtension.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.compat;
+
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+
+public interface BinaryCompatibibilityExtension {
+    RegularFileProperty getAcceptedRegressionsFile();
+    Property<Boolean> getEnabled();
+    Property<String> getBaselineVersion();
+}

--- a/src/main/groovy/io/micronaut/build/compat/InternalAnnotationCollectorRule.java
+++ b/src/main/groovy/io/micronaut/build/compat/InternalAnnotationCollectorRule.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.compat;
+
+import japicmp.model.JApiClass;
+import japicmp.model.JApiCompatibility;
+import japicmp.model.JApiHasAnnotations;
+import me.champeau.gradle.japicmp.report.AbstractContextAwareViolationRule;
+import me.champeau.gradle.japicmp.report.Violation;
+
+import java.util.HashSet;
+
+public class InternalAnnotationCollectorRule extends AbstractContextAwareViolationRule {
+    public static final String INTERNAL_TYPES = "micronaut.internal.types";
+
+    @Override
+    public Violation maybeViolation(JApiCompatibility member) {
+        if (member instanceof JApiClass) {
+            JApiClass jApiClass = (JApiClass) member;
+            maybeRecord((JApiHasAnnotations) member, jApiClass.getFullyQualifiedName());
+        }
+        return null;
+    }
+
+    private void maybeRecord(JApiHasAnnotations member, String name) {
+        if (isAnnotatedWithInternal(member)) {
+            HashSet<String> types = getContext().getUserData(INTERNAL_TYPES);
+            if (types == null) {
+                types = new HashSet<>();
+                getContext().putUserData(INTERNAL_TYPES, types);
+            }
+            types.add(name);
+        }
+    }
+
+    static boolean isAnnotatedWithInternal(JApiHasAnnotations member) {
+        return member.getAnnotations()
+                .stream()
+                .anyMatch(ann -> ann.getFullyQualifiedName().equals("io.micronaut.core.annotation.Internal"));
+    }
+}

--- a/src/main/groovy/io/micronaut/build/compat/InternalAnnotationPostProcessRule.java
+++ b/src/main/groovy/io/micronaut/build/compat/InternalAnnotationPostProcessRule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.compat;
+
+import me.champeau.gradle.japicmp.report.PostProcessViolationsRule;
+import me.champeau.gradle.japicmp.report.Severity;
+import me.champeau.gradle.japicmp.report.Violation;
+import me.champeau.gradle.japicmp.report.ViolationCheckContextWithViolations;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class InternalAnnotationPostProcessRule implements PostProcessViolationsRule {
+    @Override
+    public void execute(ViolationCheckContextWithViolations context) {
+        Set<String> internalTypes = context.getUserData(InternalAnnotationCollectorRule.INTERNAL_TYPES);
+        if (internalTypes != null) {
+            Set<String> toBeSuppressed = context.getViolations().keySet().stream().filter(internalTypes::contains).collect(Collectors.toSet());
+            Set<Map.Entry<String, List<Violation>>> entries = context.getViolations().entrySet();
+            for (Map.Entry<String, List<Violation>> entry : entries) {
+                if (toBeSuppressed.contains(entry.getKey())) {
+                    List<Violation> replacement = entry.getValue().stream().map(v -> {
+                        if (v.getSeverity() == Severity.error) {
+                            return v.withSeverity(Severity.warning);
+                        }
+                        return v;
+                    }).collect(Collectors.toList());
+                    entry.getValue().clear();
+                    entry.getValue().addAll(replacement);
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/io/micronaut/build/compat/InternalMicronautTypeRule.java
+++ b/src/main/groovy/io/micronaut/build/compat/InternalMicronautTypeRule.java
@@ -15,11 +15,14 @@
  */
 package io.micronaut.build.compat;
 
+import japicmp.model.JApiHasAnnotations;
 import me.champeau.gradle.japicmp.report.Severity;
 import me.champeau.gradle.japicmp.report.Violation;
 import me.champeau.gradle.japicmp.report.ViolationTransformer;
 
 import java.util.Optional;
+
+import static io.micronaut.build.compat.InternalAnnotationCollectorRule.isAnnotatedWithInternal;
 
 /**
  * This rule turns errors on internal types into warnings.
@@ -40,6 +43,12 @@ public class InternalMicronautTypeRule implements ViolationTransformer {
     public Optional<Violation> transform(String type, Violation violation) {
         if (isInternalType(type) && violation.getSeverity() == Severity.error) {
             return Optional.of(violation.withSeverity(Severity.warning));
+        }
+        if (violation.getMember() instanceof JApiHasAnnotations) {
+            JApiHasAnnotations member = (JApiHasAnnotations) violation.getMember();
+            if (isAnnotatedWithInternal(member)) {
+                return Optional.of(violation.withSeverity(Severity.warning));
+            }
         }
         return Optional.of(violation);
     }

--- a/src/main/groovy/io/micronaut/build/compat/InternalMicronautTypeRule.java
+++ b/src/main/groovy/io/micronaut/build/compat/InternalMicronautTypeRule.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.compat;
+
+import me.champeau.gradle.japicmp.report.PostProcessViolationsRule;
+import me.champeau.gradle.japicmp.report.Severity;
+import me.champeau.gradle.japicmp.report.Violation;
+import me.champeau.gradle.japicmp.report.ViolationCheckContextWithViolations;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This rule turns errors on internal types into warnings.
+ */
+public class InternalMicronautTypeRule implements PostProcessViolationsRule {
+    @Override
+    public void execute(ViolationCheckContextWithViolations context) {
+        Map<String, List<Violation>> violations = context.getViolations();
+        Map<String, List<Violation>> newViolations = violations.entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> {
+                            String className = e.getKey();
+                            return e.getValue().stream()
+                                    .map(violation -> {
+                                        if (isInternalType(className) && violation.getSeverity() == Severity.error) {
+                                            return violation.withSeverity(Severity.warning);
+                                        }
+                                        return violation;
+                                    })
+                                    .collect(Collectors.toList());
+                        })
+                );
+        context.getViolations().clear();
+        context.getViolations().putAll(newViolations);
+    }
+
+    private static boolean isInternalType(String className) {
+        return className.startsWith("io.micronaut") && className.contains(".internal.");
+    }
+}

--- a/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
+++ b/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.compat;
+
+import com.google.common.io.Files;
+import io.micronaut.build.MicronautPublishingPlugin;
+import me.champeau.gradle.japicmp.JapicmpTask;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * A plugin which sets up binary compatibility reports for Micronaut
+ * modules.
+ */
+public class MicronautBinaryCompatibilityPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getPlugins().withType(MicronautPublishingPlugin.class, unused -> {
+            project.getPluginManager().withPlugin("java-library", alsoUnused -> {
+                TaskContainer tasks = project.getTasks();
+                ProviderFactory providers = project.getProviders();
+                TaskProvider<FindBaselineTask> baseline = tasks.register("findBaseline", FindBaselineTask.class, task -> {
+                    task.getGithubSlug().convention(providers.gradleProperty("githubSlug"));
+                    task.getCurrentVersion().convention(providers.provider(() -> project.getVersion().toString()));
+                    task.getPreviousVersion().convention(project.getLayout().getBuildDirectory().file("baseline.txt"));
+                });
+                Configuration oldClasspath = project.getConfigurations().detachedConfiguration();
+                Configuration oldJar = project.getConfigurations().detachedConfiguration();
+                oldClasspath.getDependencies().addLater(baseline.map(baselineTask -> {
+                    String version = readBaseline(baselineTask);
+                    return project.getDependencies().create(project.getGroup() + ":micronaut-" + project.getName() + ":" + version);
+                }));
+                oldJar.getDependencies().addLater(baseline.map(baselineTask -> {
+                    String version = readBaseline(baselineTask);
+                    return project.getDependencies().create(project.getGroup() + ":micronaut-" + project.getName() + ":" + version + "@jar");
+                }));
+                TaskProvider<JapicmpTask> japicmpTask = tasks.register("japiCmp", JapicmpTask.class, task -> {
+                    task.getNewClasspath().from(project.getConfigurations().getByName("runtimeClasspath"));
+                    task.getOldClasspath().from(oldClasspath);
+                    task.getOldArchives().from(oldJar);
+                    task.richReport(report -> {
+                        report.getReportName().set("binary-compatibility-" + project.getName() + ".html");
+                        report.getTitle().set(baseline.map(baselineTask -> {
+                            String version = readBaseline(baselineTask);
+                            return "Binary compatibility report for Micronaut " + project.getName() + " " + project.getVersion() + " against " + version;
+                        }));
+                        report.getAddDefaultRules().set(true);
+                        report.addPostProcessRule(InternalMicronautTypeRule.class);
+                    });
+                    task.getIgnoreMissingClasses().set(true);
+                });
+                project.afterEvaluate(p -> {
+                    Task jar = tasks.findByName("shadowJar");
+                    if (jar == null) {
+                        jar = tasks.getByName("jar");
+                    }
+                    Task effectiveJar = jar;
+                    japicmpTask.configure(task -> task.getNewArchives().from(effectiveJar));
+                });
+            });
+        });
+    }
+
+    private static String readBaseline(FindBaselineTask baselineTask) {
+        List<String> lines;
+        try {
+            lines = Files.readLines(baselineTask.getPreviousVersion().getAsFile().get(), StandardCharsets.UTF_8);
+            if (lines.size() > 0) {
+                return lines.get(0);
+            }
+        } catch (IOException e) {
+            return "+";
+        }
+        return "+";
+    }
+}

--- a/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
+++ b/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -78,6 +79,7 @@ public class MicronautBinaryCompatibilityPlugin implements Plugin<Project> {
                     });
                     task.getIgnoreMissingClasses().set(true);
                 });
+                tasks.named("check").configure(task -> task.dependsOn(japicmpTask));
                 project.afterEvaluate(p -> {
                     Task jar = tasks.findByName("shadowJar");
                     if (jar == null) {
@@ -86,7 +88,7 @@ public class MicronautBinaryCompatibilityPlugin implements Plugin<Project> {
                     Task effectiveJar = jar;
                     japicmpTask.configure(task -> {
                         File changesFile = binaryCompatibility.getAcceptedRegressionsFile().get().getAsFile();
-                        task.getInputs().property("accepted-api-changes", changesFile).optional(true);
+                        task.getInputs().file(changesFile).withPropertyName("accepted-api-changes").withPathSensitivity(PathSensitivity.NONE).optional(true);
                         task.getNewArchives().from(effectiveJar);
                         task.richReport(report ->
                                 report.addViolationTransformer(AcceptedApiChangesRule.class,

--- a/src/main/java/io/micronaut/build/compat/FindBaselineTask.java
+++ b/src/main/java/io/micronaut/build/compat/FindBaselineTask.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.compat;
+
+import groovy.json.JsonSlurper;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@CacheableTask
+public abstract class FindBaselineTask extends DefaultTask {
+    @Input
+    public abstract Property<String> getGithubSlug();
+
+    @Input
+    public abstract Property<String> getCurrentVersion();
+
+    @OutputFile
+    public abstract RegularFileProperty getPreviousVersion();
+
+    @TaskAction
+    public void execute() {
+        String releasesUrl = "https://api.github.com/repos/" + normalizeSlug(getGithubSlug().get()) + "/releases";
+        try {
+            URL url = new URL(releasesUrl);
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("GET");
+            con.setRequestProperty("Accept", "application/vnd.github.v3+json");
+            InputStream is = con.getInputStream();
+            JsonSlurper slurper = new JsonSlurper();
+            List<Map<String, Object>> json = (List<Map<String, Object>>) slurper.parse(is);
+            List<VersionModel> releases = json.stream()
+                    .filter(release -> !Objects.equals(release.get("draft"), true) && !Objects.equals(release.get("prerelease"), true))
+                    .map(release -> (String) release.get("tag_name"))
+                    .map(tag -> {
+                        if (tag.startsWith("v")) {
+                            return tag.substring(1);
+                        }
+                        return tag;
+                    }).filter(v -> !v.contains("-"))
+                    .map(VersionModel::of)
+                    .sorted()
+                    .collect(Collectors.toList());
+            VersionModel current = VersionModel.of(trimVersion());
+            Optional<VersionModel> previous = releases.stream()
+                    .filter(v -> v.compareTo(current) < 0)
+                    .reduce((a, b) -> b);
+            if (!previous.isPresent()) {
+                throw new IllegalStateException("Could not find a previous version for " + current);
+            }
+            Files.write(getPreviousVersion().get().getAsFile().toPath(), previous.get().toString().getBytes("UTF-8"));
+        } catch (IOException e) {
+            throw new GradleException("Unable to determine previous release", e);
+        }
+    }
+
+    @NotNull
+    private String trimVersion() {
+        String version = getCurrentVersion().get();
+        int idx = version.indexOf('-');
+        if (idx >= 0) {
+            return version.substring(0, idx);
+        }
+        return version;
+    }
+
+    private static String normalizeSlug(String slug) {
+        if (slug.startsWith("/")) {
+            slug = slug.substring(1);
+        }
+        if (slug.endsWith("/")) {
+            slug = slug.substring(0, slug.length() - 1);
+        }
+        return slug;
+    }
+}

--- a/src/main/java/io/micronaut/build/compat/VersionModel.java
+++ b/src/main/java/io/micronaut/build/compat/VersionModel.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.compat;
+
+import org.jetbrains.annotations.NotNull;
+
+public class VersionModel implements Comparable<VersionModel> {
+    private final String current;
+    private final int currentAsInt;
+    private final VersionModel leaf;
+
+    public static VersionModel of(String version) {
+        int idx = version.indexOf(".");
+        if (idx < 0) {
+            return new VersionModel(version, null);
+        }
+        return new VersionModel(version.substring(0, idx), of(version.substring(idx + 1)));
+    }
+
+    private VersionModel(String current, VersionModel leaf) {
+        this.current = current;
+        this.currentAsInt = Integer.parseInt(current);
+        this.leaf = leaf;
+    }
+
+    @Override
+    public int compareTo(@NotNull VersionModel o) {
+        int result = Integer.compare(currentAsInt, o.currentAsInt);
+        if (result != 0) {
+            return result;
+        }
+        if (leaf == null && o.leaf == null) {
+            return 0;
+        }
+        if (leaf == null) {
+            return -1;
+        }
+        if (o.leaf == null) {
+            return 1;
+        }
+        return leaf.compareTo(o.leaf);
+    }
+
+    public String getCurrent() {
+        return current;
+    }
+
+    public int getCurrentAsInt() {
+        return currentAsInt;
+    }
+    
+    public String getVersion() {
+        if (leaf == null) {
+            return current;
+        }
+        return current + "." + leaf;
+    }
+
+    @Override
+    public String toString() {
+        return getVersion();
+    }
+}

--- a/src/test/groovy/io/micronaut/build/compat/VersionModelTest.groovy
+++ b/src/test/groovy/io/micronaut/build/compat/VersionModelTest.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.build.compat
+
+import spock.lang.Specification
+
+class VersionModelTest extends Specification {
+    def "compares versions"() {
+        expect:
+        v("1.0") == v("1.0")
+        v("1.0") < v("1.1")
+        v("1.2") > v("1.1")
+        v("1.1.1") > v("1.1")
+        v("1") < v("1.1")
+        v("1.0") < v("1.0.1")
+        v("0.9") < v("0.10")
+        v("0.1") < v("1.3.2")
+    }
+
+    static VersionModel v(String version) {
+        VersionModel.of(version)
+    }
+}


### PR DESCRIPTION
This PR adds a new feature to the build plugins: binary compatibility checks. It leverages the [JApiCmp Gradle Plugin](https://github.com/melix/japicmp-gradle-plugin). By default, all projects applying the `io.micronaut.build.internal.module` will automatically gain binary compatibility checks.

The checker will automatically perform verification against the latest release of a module. For this purpose, it makes use of the GitHub releases API to figure out the previous release. In case a module is a new module and that there's nothing to compare against, the binary check can be disabled by configuration:

```gradle
micronautBuild {
    binaryCompatibility {
        enabled = false
    }
}
```

It is also possible to provide an explicit baseline, instead of checking against the previous release:

```gradle
micronautBuild {
    binaryCompatibility {
        baselineVersion = "1.0.0"
    }
}
```

The plugin defines a `japicmp` task which performs binary compatibility checks against the baseline, and generates a rich HTML report for each project. For example for the `micronaut-sql` repository which defines a `jooq` project, the report for this module would be found at `jooq/build/reports/binary-compatibility-jooq.html`.

The **build will fail if a binary incompatibility is found**, unless that incompatibility is in an internal type. For now, an internal type is defined as a class which package contains `.internal.`.

In case of failure, the report would show something like this:

![image](https://user-images.githubusercontent.com/316357/157087323-e0f7d449-bd15-424a-ba45-e31410321057.png)

By clicking on the "Accept this change" button, the report will show what to do in order to accept a binary change:

![image](https://user-images.githubusercontent.com/316357/157087434-ea068db6-a597-482d-9d9a-6f169e2ef190.png)

The default location of the accepted API changes file is at the root of the project, `accepted-api-changes.json`. For example, to approve the changes above, the file would need to contain:

```json
[
  {
    "type": "io.micronaut.core.annotation.AnnotationUtil",
    "member": "Class io.micronaut.core.annotation.AnnotationUtil",
    "reason": "Field was intentionally removed"
  },
  {
    "type": "io.micronaut.core.annotation.AnnotationUtil",
    "member": "Field ZERO_ANNOTATED_ELEMENTS",
    "reason": "The field was deprecated"
  }
]
``` 

Then re-running the check would show accepted changes:

![image](https://user-images.githubusercontent.com/316357/157087837-4add8132-895c-4462-92c0-2f8ae051fc3b.png)

Therefore, with this change, **all binary breaking changes have to be accepted explicitly**.

It's worth noting that the acceptance file should be reset on each release.

This work is partly based on the same mechanisms which exist in the Gradle build. However, the conditions for acceptance, or custom rules, are much simpler in this project for now. For example, currently we need to accept 2 regressions if a field is removed: one for the field itself, and one for the class. There would be ways to remove that burden automatically if we want to invest more time.

Similarly, there's one report per submodule. We could instead generate a single report for the whole project, but it would involve more work.
