### PR TITLE
Rework BOM validation

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBomCheckerPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBomCheckerPlugin.groovy
@@ -1,73 +1,16 @@
 package io.micronaut.build
 
-
-import io.micronaut.build.pom.PomChecker
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.api.artifacts.repositories.ArtifactRepository
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository
-import org.gradle.api.plugins.BasePlugin
-
 /**
  * This plugin verifies the BOMs which are used in the project
  * version catalog.
+ * @deprecated features provided by this plugin are now part of {@link MicronautBomPlugin}
  */
+@Deprecated
 abstract class MicronautBomCheckerPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.pluginManager.apply(BasePlugin)
-        def catalog = project.extensions.findByType(VersionCatalogsExtension).named("libs")
-        project.with {
-            def checkBoms = tasks.register("checkBom")
-
-            project.tasks.named("check") {
-                dependsOn(checkBoms)
-            }
-
-            // First we create a task per BOM that we include, in order
-            // to check that they exist for the specified version and
-            // that their dependencyManagement block only contains expected
-            // dependencies
-            catalog.dependencyAliases.stream()
-                    .filter { it.startsWith("boms.") }
-                    .forEach { alias ->
-                        String name = alias.split("[.]").collect { it.capitalize() }.join('')
-                        def checker = tasks.register("check$name", PomChecker) {
-                            repositories.set([repoUrl(project.repositories.findByName("MavenRepo"))])
-                            pomCoordinates.set(catalog.findDependency(alias).map {
-                                it.map { "${it.module.group}:${it.module.name}:${it.versionConstraint.requiredVersion}".toString() }
-                            }.get())
-                            checkBomContents.set(true)
-                            report.set(layout.buildDirectory.file("reports/boms/${alias}.txt"))
-                        }
-                        checkBoms.configure {
-                            it.dependsOn(checker)
-                        }
-                    }
-
-            // Then we create a task per dependency we include in the BOM
-            // to check that it exists
-            catalog.dependencyAliases.stream()
-                    .filter { it.startsWith("managed.") }
-                    .forEach { alias ->
-                        String name = alias.split("[.]").collect { it.capitalize() }.join('')
-                        def checker = tasks.register("check$name", PomChecker) {
-                            repositories.set([repoUrl(project.repositories.findByName("MavenRepo"))] + project.repositories.collect { repoUrl(it) })
-                            pomCoordinates.set(catalog.findDependency(alias).map {
-                                it.map { "${it.module.group}:${it.module.name}:${it.versionConstraint.requiredVersion}".toString() }
-                            }.get())
-                            checkBomContents.set(false)
-                            report.set(layout.buildDirectory.file("reports/dependencies/${alias}.txt"))
-                        }
-                        checkBoms.configure {
-                            it.dependsOn(checker)
-                        }
-                    }
-        }
-    }
-
-    static String repoUrl(ArtifactRepository repository) {
-        (repository as MavenArtifactRepository).url
+        project.getLogger().warn("This plugin is deprecated and will be removed in a future version. It has been turned into a no-op.")
     }
 }

--- a/src/main/groovy/io/micronaut/build/pom/BomSuppressions.java
+++ b/src/main/groovy/io/micronaut/build/pom/BomSuppressions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.pom;
+
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
+
+import java.util.Set;
+
+public interface BomSuppressions {
+    /**
+     * This property can be used to declare the set of g:a:v coordinates
+     * of dependencies reported with problems in BOM checking, but that
+     * we should ignore.
+     * @return the silenced dependencies
+     */
+    @Input
+    SetProperty<String> getDependencies();
+
+    /**
+     * This property can be used to define a set of group ids which are
+     * allowed when a BOM defines a dependency on a group which is not
+     * its own group.
+     */
+    @Input
+    MapProperty<String, Set<String>> getBomAuthorizedGroupIds();
+}

--- a/src/main/groovy/io/micronaut/build/pom/CheckPomAction.java
+++ b/src/main/groovy/io/micronaut/build/pom/CheckPomAction.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.pom;
+
+import groovy.json.JsonGenerator;
+import groovy.json.JsonOutput;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * This work action is responsible for checking the contents of a POM file.
+ * It will verify that:
+ * <ul>
+ *     <li>All dependencies declared in the POM file exist in a repository</li>
+ *     <li>If it's a BOM file, verify that all the dependencies it talks about belong to the same group as the BOM itself</li>
+ *     <li>If it's a BOM file, make sure that it doesn't import other BOMs</li>
+ * </ul>
+ */
+public abstract class CheckPomAction implements WorkAction<CheckPomAction.Parameters> {
+    interface Parameters extends WorkParameters {
+        Property<String> getDependencyPath();
+
+        ListProperty<String> getRepositories();
+
+        Property<String> getGroupId();
+
+        Property<String> getArtifactId();
+
+        Property<String> getVersion();
+
+        RegularFileProperty getPomFile();
+
+        RegularFileProperty getReportFile();
+
+        DirectoryProperty getPomDirectory();
+    }
+
+    @Override
+    public void execute() {
+        String dependencyPath = getParameters().getDependencyPath().get();
+        File pomFile = getParameters().getPomFile().getAsFile().get();
+        File reportFile = getParameters().getReportFile().getAsFile().get();
+        String groupId = getParameters().getGroupId().get();
+        String artifactId = getParameters().getArtifactId().get();
+        String version = getParameters().getVersion().get();
+        File pomDirectory = getParameters().getPomDirectory().getAsFile().get();
+        List<String> repositories = getParameters().getRepositories().get();
+        PomDownloader downloader = new PomDownloader(repositories, pomDirectory);
+        PomParser parser = new PomParser(downloader);
+        PomFile pom = parser.parse(pomFile, groupId, artifactId, version);
+        Map<String, String> foundDependencies = Collections.synchronizedMap(new LinkedHashMap<>());
+        Set<String> missingDependencies = Collections.synchronizedSet(new LinkedHashSet<>());
+        pom.getDependencies().parallelStream().forEach(dependency -> {
+            String key = dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + dependency.getVersion();
+            Optional<File> downloadedFile = downloader.tryDownloadPom(dependency);
+            if (downloadedFile.isPresent()) {
+                foundDependencies.put(key, downloadedFile.get().getAbsolutePath());
+            } else {
+                missingDependencies.add(key);
+            }
+        });
+        PomValidation validation = new PomValidation(dependencyPath, pom, foundDependencies, missingDependencies);
+        JsonGenerator generator = new JsonGenerator.Options()
+                .excludeFieldsByName("import", "importingBom")
+                .build();
+        String json = JsonOutput.prettyPrint(generator.toJson(validation));
+        try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(reportFile), "UTF-8")) {
+            writer.write(json);
+        } catch (IOException e) {
+            throw new GradleException("Unable to write report", e);
+        }
+    }
+
+}

--- a/src/main/groovy/io/micronaut/build/pom/MicronautBomExtension.java
+++ b/src/main/groovy/io/micronaut/build/pom/MicronautBomExtension.java
@@ -15,11 +15,13 @@
  */
 package io.micronaut.build.pom;
 
+import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.specs.Spec;
+import org.gradle.api.tasks.Nested;
 
 /**
  * Extension to configure BOM projects.
@@ -101,4 +103,11 @@ public interface MicronautBomExtension {
      * @return the property name
      */
     Property<String> getPropertyName();
+
+    @Nested
+    BomSuppressions getSuppressions();
+
+    default void suppressions(Action<? super BomSuppressions> spec) {
+        spec.execute(getSuppressions());
+    }
 }

--- a/src/main/groovy/io/micronaut/build/pom/PomChecker.groovy
+++ b/src/main/groovy/io/micronaut/build/pom/PomChecker.groovy
@@ -180,7 +180,10 @@ abstract class PomChecker extends DefaultTask {
             // We have a BOM which imports another BOM. This should only
             // be allowed for Micronaut BOMs themselves
             if (!validation.pomFile.groupId.startsWith("io.micronaut")) {
-                errors.errors.add("BOM ${validation.pomFile.groupId}:${validation.pomFile.artifactId}:${validation.pomFile.version} imports another BOM but is not a Micronaut BOM".toString())
+                validation.pomFile.findImports().each {
+                    String dependency = "${it.groupId}:${it.artifactId}:${it.version}"
+                    errors.error(dependency, "BOM ${validation.pomFile.groupId}:${validation.pomFile.artifactId}:${validation.pomFile.version} (via $validation.dependencyPath) is not a Micronaut BOM but it imports another BOM ($dependency)".toString())
+                }
             }
         }
     }

--- a/src/main/groovy/io/micronaut/build/pom/PomChecker.groovy
+++ b/src/main/groovy/io/micronaut/build/pom/PomChecker.groovy
@@ -1,22 +1,25 @@
 package io.micronaut.build.pom
 
-import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
-import groovy.xml.XmlSlurper
-import groovy.xml.slurpersupport.GPathResult
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.workers.WorkerExecutor
+
+import javax.inject.Inject
 
 import static org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
 
@@ -35,102 +38,170 @@ abstract class PomChecker extends DefaultTask {
     @Input
     abstract Property<Boolean> getFailOnError()
 
-    @Input
-    abstract Property<Boolean> getFailOnBomContents()
-
     @InputFile
     @PathSensitive(PathSensitivity.NONE)
     @Optional
     abstract RegularFileProperty getPomFile()
 
-    @Input
-    abstract Property<Boolean> getCheckBomContents()
+    @Nested
+    abstract Property<BomSuppressions> getSuppressions()
 
-    @OutputFile
-    abstract RegularFileProperty getReport()
+    @OutputDirectory
+    abstract DirectoryProperty getReportDirectory()
+
+    @Internal
+    abstract DirectoryProperty getPomsDirectory()
+
+    @Inject
+    abstract WorkerExecutor getWorkerExecutor()
 
     PomChecker() {
         description = "Verifies a POM file"
         group = VERIFICATION_GROUP
         getFailOnError().convention(true)
         getFailOnSnapshots().convention(getPomCoordinates().map(v -> !v.endsWith("-SNAPSHOT")))
-        getFailOnBomContents().convention(getPomCoordinates().map(v -> !v.startsWith("io.micronaut")))
     }
 
     @TaskAction
     void verifyBom() {
-        List<String> errors = []
-        boolean found = false
-        for (String repositoryUrl : repositories.get()) {
-            def coordinates = pomCoordinates.get().split(':')
-            if (coordinates.length != 3) {
-                throw new GradleException("Incorrect BOM coordinates '${pomCoordinates.get()}': should be of the form group:artifact:version ")
-            }
-            def (group, artifact, version) = [coordinates[0], coordinates[1], coordinates[2]]
-            if (repositoryUrl.endsWith('/')) {
-                repositoryUrl = repositoryUrl.substring(0, repositoryUrl.length() - 1)
-            }
-            def uri = "$repositoryUrl/${group.replace((char) '.', (char) '/')}/${artifact}/${version}/${artifact}-${version}.pom"
-            try {
-                def pom
-                if (pomFile.present) {
-                    pom = new XmlSlurper().parse(pomFile.asFile.get())
-                } else {
-                    pom = new XmlSlurper().parse(uri)
-                }
-                if (checkBomContents.get()) {
-                    assertDependencyManagementConfinedToGroup(pom, group, artifact, errors)
-                }
-                if (version.endsWith("-SNAPSHOT")) {
-                    String message = "Dependency ${pomCoordinates.get()} is a SNAPSHOT"
-                    if (failOnSnapshots.get()) {
-                        errors << message
-                    } else {
-                        logger.warn(message)
+        Set<String> silencedDeps = suppressions.get().dependencies.get()
+        Map<String, Set<String>> bomAuthorizedGroupIds = suppressions.get().bomAuthorizedGroupIds.get()
+        ErrorCollector errorCollector = new ErrorCollector(silencedDeps)
+        def coordinates = pomCoordinates.get().split(':')
+        if (coordinates.length != 3) {
+            throw new GradleException("Incorrect BOM coordinates '${pomCoordinates.get()}': should be of the form group:artifact:version ")
+        }
+        def queue = new ArrayDeque<List<Object>>()
+        queue.add([coordinates[0], coordinates[1], coordinates[2], pomFile.get().asFile, pomCoordinates.get()] as List<Object>)
+        def workQueue = workerExecutor.noIsolation()
+        Set<String> seen = []
+        while (!queue.isEmpty()) {
+            List<File> reports = []
+            queue.each { item ->
+                def (group, artifact, version, pomFile, path) = [item[0], item[1], item[2], item[3], item[4]]
+                String key = "${group}:${artifact}:${version}"
+                if (seen.add(key)) {
+                    workQueue.submit(CheckPomAction) { CheckPomAction.Parameters params ->
+                        params.pomFile.set((File) pomFile)
+                        params.groupId.set((String) group)
+                        params.artifactId.set((String) artifact)
+                        params.version.set((String) version)
+                        params.repositories.set(repositories)
+                        params.getDependencyPath().set((String) path)
+                        def reportFile = reportDirectory.file("${group}-${artifact}-${version}.json")
+                        reports.add(reportFile.get().asFile)
+                        params.reportFile.set(reportFile)
+                        params.pomDirectory.set(pomsDirectory)
                     }
                 }
-                found = true
-                break
-            } catch (Exception ex) {
-                getLogger().debug("Skipping repository $repositoryUrl as the POM file is missing or corrupt")
+            }
+            workQueue.await()
+            queue.clear()
+            reports.each {
+                def validation = PomFileAdapter.parseFromFile(it)
+                String bomPrefix = "BOM ${validation.pomFile.groupId}:${validation.pomFile.artifactId}:${validation.pomFile.version} (via ${validation.dependencyPath})"
+                assertThatImportingBomIsAllowed(validation, errorCollector)
+                if (validation.pomFile.bom) {
+                    addTransitiveBomsToQueue(validation, queue)
+                    if (validation.pomFile.dependencies.any { !it.managed }) {
+                        errorCollector.errors.add("$bomPrefix has dependencies outside of <dependencyManagement> block.".toString())
+                    }
+                    def groupId = validation.pomFile.groupId
+                    def artifactId = validation.pomFile.artifactId
+                    def version = validation.pomFile.version
+                    Set<String> allowedGroups = bomAuthorizedGroupIds.get("${groupId}:${artifactId}".toString())
+                    if (allowedGroups == null) {
+                        allowedGroups = bomAuthorizedGroupIds.getOrDefault("${groupId}:${artifactId}:${version}".toString(), [] as Set)
+                    }
+                    if (!groupId.startsWith("io.micronaut")) {
+                        validation.pomFile.dependencies.findAll {
+                            it.managed && !it.groupId.startsWith(groupId)
+                        }.each {
+                            String dependency = "${it.groupId}:${it.artifactId}:${it.version}"
+                            String message = "$bomPrefix declares dependency on ${dependency} which doesn't belong to group ${groupId}.".toString()
+                            if (allowedGroups.contains(it.groupId)) {
+                                errorCollector.silenced(message)
+                            } else {
+                                errorCollector.error(dependency, message)
+                            }
+                        }
+                    }
+                }
+                validation.invalidDependencies.each {
+                    if (!it.startsWith("io.micronaut") || !it.endsWith("-SNAPSHOT")) {
+                        errorCollector.error(it, "$bomPrefix declares a non-resolvable dependency: $it".toString())
+                    }
+                }
+                if (failOnSnapshots.get()) {
+                    validation.pomFile.dependencies.findAll {
+                        it.version.endsWith("-SNAPSHOT")
+                    }.each {
+                        String dependency = "${it.groupId}:${it.artifactId}:${it.version}"
+                        errorCollector.error(dependency, "$bomPrefix declares a SNAPSHOT dependency on ${dependency}".toString())
+                    }
+                }
             }
         }
-        if (!found) {
-            errors << "Dependency ${pomCoordinates.get()} is wasn't found in any repository".toString()
+
+        File reportFile = writeReport(errorCollector.errors)
+        if (failOnError.get() && errorCollector.errors) {
+            throw new GradleException("BOM verification failed. See report in ${reportFile}")
         }
-        def reportFile = report.asFile.get()
-        def reportDir = reportFile.parentFile
-        if (reportDir.directory || reportDir.mkdirs()) {
-            reportFile.text = errors.join("\n")
-        } else {
-            throw new GradleException("Unable to write report file to ${reportFile}")
+    }
+
+    private File writeReport(List<String> errors) {
+        def reportFile = reportDirectory.file("report-${name}.txt").get().asFile
+        reportFile.withWriter { writer ->
+            errors.each {
+                println it
+                writer.println(it)
+            }
         }
-        if (errors) {
-            String message = "Validation failed for ${pomCoordinates.get()}. Check the report at ${reportFile} for details."
-            if (failOnError.get()) {
-                throw new GradleException(message)
-            } else {
-                logger.error(message)
+        reportFile
+    }
+
+    private static void addTransitiveBomsToQueue(PomValidation validation, Deque<List<Object>> queue) {
+        validation.validDependencies.each { gav, file ->
+            def coord = gav.split(':')
+            String group = coord[0]
+            String artifact = coord[1]
+            String version = coord[2]
+            def dependency = validation.pomFile.dependencies.find {
+                it.groupId == group && it.artifactId == artifact && it.version == version
+            }
+            if (dependency.managed && dependency.import) {
+                queue.add([group, artifact, version, new File(file), "${validation.dependencyPath} -> $gav".toString()] as List<Object>)
             }
         }
     }
 
-    @CompileDynamic
-    private void assertDependencyManagementConfinedToGroup(GPathResult pom, String group, String name, List<String> errors) {
-        boolean failOnError = failOnBomContents.get()
-        String prefix = failOnError ? 'Error validating' : 'Warning:'
-        pom.dependencyManagement.dependencies.dependency.each {
-            String depGroup = it.groupId.text().replace('${project.groupId}', group)
-            if (!depGroup.startsWith(group)) {
-                def scope = it.scope.text()
-                if (scope != 'import') {
-                    String message = "$prefix BOM [${name}]: includes the dependency [${it.groupId}:${it.artifactId}:${it.version}] which doesn't start with the group id of the BOM: [${group}]"
-                    if (failOnError) {
-                        errors << message
-                    } else {
-                        logger.warn(message)
-                    }
-                }
+    private static void assertThatImportingBomIsAllowed(PomValidation validation, ErrorCollector errors) {
+        if (validation.pomFile.bom && validation.pomFile.importingBom) {
+            // We have a BOM which imports another BOM. This should only
+            // be allowed for Micronaut BOMs themselves
+            if (!validation.pomFile.groupId.startsWith("io.micronaut")) {
+                errors.errors.add("BOM ${validation.pomFile.groupId}:${validation.pomFile.artifactId}:${validation.pomFile.version} imports another BOM but is not a Micronaut BOM".toString())
+            }
+        }
+    }
+
+    private static class ErrorCollector {
+        private final Set<String> silencedDependencies
+        final List<String> errors = []
+
+        ErrorCollector(Set<String> silencedDependencies) {
+            this.silencedDependencies = silencedDependencies
+        }
+
+        void silenced(String message) {
+            println("[Silenced] $message")
+        }
+
+        void error(String dependency, String message) {
+            if (!silencedDependencies.contains(dependency)) {
+                errors << message
+            } else {
+                silenced(message)
             }
         }
     }

--- a/src/main/groovy/io/micronaut/build/pom/PomDependency.java
+++ b/src/main/groovy/io/micronaut/build/pom/PomDependency.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.pom;
+
+public final class PomDependency {
+    private final boolean isManaged;
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+    private final String scope;
+
+    public PomDependency(boolean isManaged, String groupId, String artifactId, String version, String scope) {
+        this.isManaged = isManaged;
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        this.scope = scope;
+    }
+
+    public boolean isManaged() {
+        return isManaged;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    @Override
+    public String toString() {
+        return groupId + ":" + artifactId + ":" + version + (!scope.isEmpty() ? " scope " + scope : "");
+    }
+
+    public boolean isImport() {
+        return "import".equals(scope);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PomDependency that = (PomDependency) o;
+
+        if (isManaged != that.isManaged) {
+            return false;
+        }
+        if (!groupId.equals(that.groupId)) {
+            return false;
+        }
+        if (!artifactId.equals(that.artifactId)) {
+            return false;
+        }
+        if (!version.equals(that.version)) {
+            return false;
+        }
+        return scope.equals(that.scope);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (isManaged ? 1 : 0);
+        result = 31 * result + groupId.hashCode();
+        result = 31 * result + artifactId.hashCode();
+        result = 31 * result + version.hashCode();
+        result = 31 * result + scope.hashCode();
+        return result;
+    }
+}

--- a/src/main/groovy/io/micronaut/build/pom/PomDownloader.java
+++ b/src/main/groovy/io/micronaut/build/pom/PomDownloader.java
@@ -33,13 +33,11 @@ public class PomDownloader {
     }
 
     public Optional<File> tryDownloadPom(PomDependency dependency) {
-        for (String repository : repositories) {
-            Optional<File> pomFile = tryDownloadPom(dependency, repository);
-            if (pomFile.isPresent()) {
-                return pomFile;
-            }
-        }
-        return Optional.empty();
+        return repositories.stream()
+                .map(repositoryUrl -> tryDownloadPom(dependency, repositoryUrl))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
     }
 
     private Optional<File> tryDownloadPom(PomDependency dependency, String repositoryUrl) {

--- a/src/main/groovy/io/micronaut/build/pom/PomDownloader.java
+++ b/src/main/groovy/io/micronaut/build/pom/PomDownloader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.pom;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Optional;
+
+public class PomDownloader {
+    private final List<String> repositories;
+    private final File pomsDirectory;
+
+    public PomDownloader(List<String> repositories, File pomDirectory) {
+        this.repositories = repositories;
+        this.pomsDirectory = pomDirectory;
+    }
+
+    public Optional<File> tryDownloadPom(PomDependency dependency) {
+        for (String repository : repositories) {
+            Optional<File> pomFile = tryDownloadPom(dependency, repository);
+            if (pomFile.isPresent()) {
+                return pomFile;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<File> tryDownloadPom(PomDependency dependency, String repositoryUrl) {
+        if (repositoryUrl.endsWith("/")) {
+            repositoryUrl = repositoryUrl.substring(0, repositoryUrl.length() - 1);
+        }
+        String group = dependency.getGroupId();
+        String artifact = dependency.getArtifactId();
+        String version = dependency.getVersion();
+        String pomFilePath = "/" + group.replace('.', '/') + "/" + artifact + "/" + version + "/" + artifact + "-" + version + ".pom";
+        String uri = repositoryUrl + pomFilePath;
+        try {
+            URL url = new URL(uri);
+            File pomFile = new File(pomsDirectory, pomFilePath);
+            if (!pomFile.exists()) {
+                try (InputStream in = url.openStream()) {
+                    pomFile.getParentFile().mkdirs();
+                    Files.copy(in, pomFile.toPath());
+                }
+            }
+            return Optional.of(pomFile);
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/groovy/io/micronaut/build/pom/PomFile.java
+++ b/src/main/groovy/io/micronaut/build/pom/PomFile.java
@@ -17,6 +17,7 @@ package io.micronaut.build.pom;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class PomFile {
     private final String groupId;
@@ -60,6 +61,12 @@ public class PomFile {
     public boolean isImportingBom() {
         return dependencies.stream()
                 .anyMatch(PomDependency::isImport);
+    }
+
+    public List<PomDependency> findImports() {
+        return dependencies.stream()
+                .filter(PomDependency::isImport)
+                .collect(Collectors.toList());
     }
 
     public List<PomDependency> getDependencies() {

--- a/src/main/groovy/io/micronaut/build/pom/PomFile.java
+++ b/src/main/groovy/io/micronaut/build/pom/PomFile.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.pom;
+
+import java.util.List;
+import java.util.Map;
+
+public class PomFile {
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+
+    private final boolean isBom;
+    private final List<PomDependency> dependencies;
+    private final Map<String, String> properties;
+
+    public PomFile(String groupId,
+                   String artifactId,
+                   String version,
+                   boolean bom,
+                   List<PomDependency> dependencies,
+                   Map<String, String> properties) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        this.isBom = bom;
+        this.dependencies = dependencies;
+        this.properties = properties;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public boolean isBom() {
+        return isBom;
+    }
+
+    public boolean isImportingBom() {
+        return dependencies.stream()
+                .anyMatch(PomDependency::isImport);
+    }
+
+    public List<PomDependency> getDependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public String toString() {
+        return "PomFile{" +
+                "isBom=" + isBom +
+                ", dependencies=" + dependencies +
+                '}';
+    }
+
+}

--- a/src/main/groovy/io/micronaut/build/pom/PomFileAdapter.groovy
+++ b/src/main/groovy/io/micronaut/build/pom/PomFileAdapter.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.build.pom
+
+import groovy.json.JsonSlurper
+
+class PomFileAdapter {
+    static PomValidation parseFromFile(File path) {
+        def json = new JsonSlurper().parse(path)
+        def pomFile = new PomFile(
+                json.pomFile.groupId, json.pomFile.artifactId, json.pomFile.version,
+                json.pomFile.bom,
+                json.pomFile.dependencies.collect { toDependency(it) },
+                json.pomFile.properties
+        )
+        def dependencyPath = json.dependencyPath
+        def validation = new PomValidation(dependencyPath, pomFile, json.validDependencies, json.invalidDependencies as Set)
+        return validation
+    }
+
+    static PomDependency toDependency(Object json) {
+        new PomDependency(
+                json.managed,
+                json.groupId,
+                json.artifactId,
+                json.version,
+                json.scope
+        )
+    }
+}

--- a/src/main/groovy/io/micronaut/build/pom/PomParser.groovy
+++ b/src/main/groovy/io/micronaut/build/pom/PomParser.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.build.pom
+
+import groovy.transform.PackageScope
+import groovy.xml.XmlSlurper
+
+@PackageScope
+class PomParser {
+    private final PomDownloader pomDownloader
+
+    PomParser(PomDownloader pomDownloader) {
+        this.pomDownloader = pomDownloader
+    }
+
+    PomFile parse(File pomFile, String groupId, String artifactId, String version) {
+        def pom = new XmlSlurper().parse(pomFile)
+        def bom = pom.packaging.text() == 'pom'
+        Map<String, String> properties = pom.properties.children().collectEntries {
+            [it.name(), it.text()]
+        }
+        if (!properties.containsKey("project.version")) {
+            properties['project.version'] = version
+        }
+        def parentGroupId = pom.parent.groupId.text()
+        def parentArtifactId = pom.parent.artifactId.text()
+        def parentVersion = pom.parent.version.text()
+        if (parentGroupId && parentArtifactId && parentVersion) {
+            Optional<File> parentPom = pomDownloader.tryDownloadPom(new PomDependency(
+                    false,
+                    parentGroupId,
+                    parentArtifactId,
+                    parentVersion,
+                    ""
+            ))
+            if (parentPom.present) {
+                PomFile parent = parse(parentPom.get(), parentGroupId, parentArtifactId, parentVersion)
+                parent.properties.each { k, v ->
+                    if (!properties.containsKey(k)) {
+                        properties.put(k, v)
+                    }
+                }
+            }
+        }
+        def managedDependencies = pom.dependencyManagement.dependencies.dependency.collect {
+            parseDependency(it, groupId, true, properties)
+        }
+        def dependencies = pom.dependencies.dependency.collect {
+            parseDependency(it, groupId, false, properties)
+        }
+        return new PomFile(groupId, artifactId, version, bom, dependencies + managedDependencies, properties)
+    }
+
+    static PomDependency parseDependency(Object model, String group, boolean managed, Map<String, String> properties) {
+        String depGroup = model.groupId.text().replace('${project.groupId}', group)
+        String depArtifact = model.artifactId.text()
+        String depVersion = model.version.text()
+        boolean substituteProperties = true
+        while (substituteProperties) {
+            substituteProperties = false
+            for (Map.Entry<String, String> property : properties) {
+                if (depVersion == "\${${property.key}}" || depVersion == "\$${property.key}") {
+                    depVersion = property.value
+                    substituteProperties = true // need to recurse because some properties can reference others
+                    break
+                }
+            }
+        }
+        String depScope = model.scope.text()
+        new PomDependency(managed, depGroup, depArtifact, depVersion, depScope)
+    }
+}

--- a/src/main/groovy/io/micronaut/build/pom/PomValidation.java
+++ b/src/main/groovy/io/micronaut/build/pom/PomValidation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.pom;
+
+import java.util.Map;
+import java.util.Set;
+
+public class PomValidation {
+    private final String dependencyPath;
+    private final PomFile pomFile;
+    private final Map<String, String> validDependencies;
+    private final Set<String> invalidDependencies;
+
+    public PomValidation(String dependencyPath,
+                         PomFile pomFile,
+                         Map<String, String> validDependencies,
+                         Set<String> invalidDependencies) {
+        this.dependencyPath = dependencyPath;
+        this.pomFile = pomFile;
+        this.validDependencies = validDependencies;
+        this.invalidDependencies = invalidDependencies;
+    }
+
+    public String getDependencyPath() {
+        return dependencyPath;
+    }
+
+    public PomFile getPomFile() {
+        return pomFile;
+    }
+
+    public Map<String, String> getValidDependencies() {
+        return validDependencies;
+    }
+
+    public Set<String> getInvalidDependencies() {
+        return invalidDependencies;
+    }
+}

--- a/src/main/java/io/micronaut/build/compat/VersionModel.java
+++ b/src/main/java/io/micronaut/build/compat/VersionModel.java
@@ -32,8 +32,16 @@ public class VersionModel implements Comparable<VersionModel> {
 
     private VersionModel(String current, VersionModel leaf) {
         this.current = current;
-        this.currentAsInt = Integer.parseInt(current);
+        this.currentAsInt = parseInt(current);
         this.leaf = leaf;
+    }
+
+    private static int parseInt(String current) {
+        try {
+            return Integer.parseInt(current);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     @Override


### PR DESCRIPTION
This commit completely reworks how BOM validation works. Now we're validating
BOMs from the _generated BOM_, recursively. Any validation problem will
immediately fail the build, requiring explicit configuration to accept
problems. There are 2 ways to silence problems:

- using `micronautBom.suppressions.dependencies` to accept individual
problems on dependencies
- using `micronautBom.suppressions.bomAuthorizedGroupIds` for BOMs
which contain dependencies on artifacts belonging to different groups

Compared to the previous code, this one will perform _recursive_
validation, visiting transitive BOMS which are included.

Fixes #286 