### PR TITLE
Map the runtime scope to runtimeOnly for doc snippets

### DIFF
--- a/src/main/groovy/io/micronaut/docs/BuildDependencyMacro.groovy
+++ b/src/main/groovy/io/micronaut/docs/BuildDependencyMacro.groovy
@@ -137,7 +137,8 @@ class BuildDependencyMacro extends InlineMacroProcessor implements ValueAtAttrib
                 return 'testImplementation'
             case 'test':
                 return 'testImplementation'
-            break
+            case 'runtime':
+                return 'runtimeOnly'
             case 'provided':
                 return 'developmentOnly'
             default: return s

--- a/src/test/groovy/io/micronaut/docs/BuildDependencyMacroSpec.groovy
+++ b/src/test/groovy/io/micronaut/docs/BuildDependencyMacroSpec.groovy
@@ -19,6 +19,24 @@ class BuildDependencyMacroSpec extends Specification {
         content.contains('implementation(<span class="hljs-string">"io.micronaut:micronaut-function-aws-alexa")')
     }
 
+    void "runtime scope is mapped to runtimeOnly in Gradle and kept in Maven"() {
+        when:
+        String content = BuildDependencyMacro.contentForTargetAndAttributes("micronaut-function-aws-alexa", [scope: 'runtime'])
+
+        then:
+        content.contains('data-lang="gradle">runtimeOnly')
+
+        and: 'only one gradle version is shown'
+        !content.contains('data-lang="gradle-groovy">runtimeOnly')
+        !content.contains('data-lang="gradle-kotlin">runtimeOnly')
+
+        and: 'snippet is kotlin compatible. It contains parenthesis and double quotes'
+        content.contains('runtimeOnly(<span class="hljs-string">"io.micronaut:micronaut-function-aws-alexa")')
+
+        and: 'maven snippet has correct scope'
+        content.contains('&lt;scope&gt;runtime&lt;/scope&gt;')
+    }
+
     void "version appears after the 2nd column for gradle"() {
         when:
         def content = BuildDependencyMacro.contentForTargetAndAttributes("artifactId", ["text": 'version="1.2.3"'])


### PR DESCRIPTION
Fixes #293

I also removed a `break` statement that I couldn't see as serving any purpose