### PR TITLE
Improve how we decide to include a project in BOM

### DIFF
--- a/src/main/groovy/io/micronaut/build/pom/MicronautBomExtension.java
+++ b/src/main/groovy/io/micronaut/build/pom/MicronautBomExtension.java
@@ -104,6 +104,14 @@ public interface MicronautBomExtension {
      */
     Property<String> getPropertyName();
 
+    /**
+     * Determines if the projects to include in the BOM are inferred,
+     * in which case it would automatically include projects which
+     * apply the publishing plugin.
+     * @return the infer property
+     */
+    Property<Boolean> getInferProjectsToInclude();
+
     @Nested
     BomSuppressions getSuppressions();
 


### PR DESCRIPTION
Before this change, the only way to exclude a project from the BOM
was to use the `excludeXXX` methods on `micronautBom` extension.
With this change, by default, we will now only include projects
which apply the `publishing` plugin, that is to say the projects
which are supposed to be published on Maven Central.

In case this causes problems, it is possible to disable inference
by setting the appropriate property:

```gradle
micronautBom {
    inferProjectsToInclude = false
}
```

The plugin will now also show which projects are included
when creating the POM file.

This should reduce problems like https://github.com/micronaut-projects/micronaut-data/pull/1404.

I have tested this on `micronaut-data`, which configuration for the BOM can now be reduced to:

```gradle
plugins {
    id 'io.micronaut.build.internal.bom'
}

group projectGroupId
version projectVersion
```

Note how there's no need to set excludes anymore.