### PR TITLE
Fix how catalogs are updated on CI

### DIFF
--- a/src/main/java/io/micronaut/build/catalogs/tasks/VersionCatalogUpdate.java
+++ b/src/main/java/io/micronaut/build/catalogs/tasks/VersionCatalogUpdate.java
@@ -90,6 +90,7 @@ public abstract class VersionCatalogUpdate extends DefaultTask {
                 getLogger().info("Didn't find any version catalog to process");
             }
             for (File catalog : catalogs) {
+                getLogger().info("Processing {}", catalog);
                 updateCatalog(catalog, new File(outputDir, catalog.getName()), logFile);
             }
         } else {


### PR DESCRIPTION
The use of the `copy` task with the same input and output directory
was causing the `gradle` directory to be emptied, instead of
creating a PR which properly upgrades dependencies.

This for example fixes incorrect PRs like https://github.com/micronaut-projects/micronaut-aot/pull/62