### PR TITLE
Add support for predictive test selection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     }
 
     implementation 'com.gradle:gradle-enterprise-gradle-plugin:3.10'
+    implementation 'com.gradle.enterprise:test-distribution-gradle-plugin:2.3'
     implementation 'org.nosphere.gradle.github:gradle-github-actions-plugin:1.3.2'
     implementation 'com.gradle:common-custom-user-data-gradle-plugin:1.6.5'
     implementation 'org.gradle:test-retry-gradle-plugin:1.3.2'

--- a/src/main/java/io/micronaut/build/MicronautGradleEnterprisePlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautGradleEnterprisePlugin.java
@@ -18,6 +18,7 @@ package io.micronaut.build;
 import com.gradle.CommonCustomUserDataGradlePlugin;
 import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
 import com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin;
+import com.gradle.enterprise.gradleplugin.testdistribution.TestDistributionPlugin;
 import com.gradle.scan.plugin.BuildScanExtension;
 import org.gradle.api.Plugin;
 import org.gradle.api.initialization.Settings;
@@ -39,6 +40,7 @@ public class MicronautGradleEnterprisePlugin implements Plugin<Settings> {
         PluginManager pluginManager = settings.getPluginManager();
         pluginManager.apply(MicronautBuildSettingsPlugin.class);
         pluginManager.apply(GradleEnterprisePlugin.class);
+        pluginManager.apply(TestDistributionPlugin.class);
         pluginManager.apply(CommonCustomUserDataGradlePlugin.class);
         GradleEnterpriseExtension ge = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
         MicronautBuildSettingsExtension micronautBuildSettingsExtension = settings.getExtensions().getByType(MicronautBuildSettingsExtension.class);


### PR DESCRIPTION
This commit adds support for preditive test selection, reducing feedback
times when enabled. Predictive selection is enabled by default for local
builds, unless the `PREDICTIVE_TEST_SELECTION` environment variable or
`predictiveTestSelection` system property is set to `false`.

On CI this would depend on whether the above environment variable or
system property is set to `true` for each workflow.

Tested on Micronaut Core: https://ge.micronaut.io/s/ziotydt2gwbna

As per @eriwen's recommendation, this should only be enabled on CI for pull requests. This means our build template workflows should probably set the `PREDICTIVE_TEST_SELECTION` if the branch is a PR (I'm not sure how to do this with GitHub actions configuration files).

