### PR TITLE
Expose test selection property via build environment

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -108,21 +108,7 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
             }
         }
 
-        // Predictive test selection is enabled if:
-        // an environment variable is explicitly configured and set to true
-        // or a system property is explicitly configured and set to true
-        // or it's a local build
-        def testSelectionEnabled = project.providers.environmentVariable("PREDICTIVE_TEST_SELECTION")
-                .orElse(project.providers.systemProperty("predictiveTestSelection"))
-                .map {
-                    if (it.trim()) {
-                        Boolean.parseBoolean(it)
-                    } else {
-                        true
-                    }
-                }
-                .orElse(micronautBuildExtension.environment.isNotGithubAction())
-
+        def testSelectionEnabled = micronautBuildExtension.environment.isTestSelectionEnabled()
         project.dependencies {
             testImplementation(testSelectionEnabled.map { enabled ->
                 if (enabled) {

--- a/src/main/java/io/micronaut/build/BuildEnvironment.java
+++ b/src/main/java/io/micronaut/build/BuildEnvironment.java
@@ -26,7 +26,7 @@ public class BuildEnvironment {
 
     public BuildEnvironment(ProviderFactory providers) {
         this.providers = providers;
-        this.githubAction = trueWhenEnvVarPresent( "GITHUB_ACTIONS");
+        this.githubAction = trueWhenEnvVarPresent("GITHUB_ACTIONS");
         this.isMigrationActive = !providers.systemProperty("strictBuild")
                 .forUseAtConfigurationTime()
                 .isPresent();
@@ -45,6 +45,22 @@ public class BuildEnvironment {
                 .forUseAtConfigurationTime()
                 .map(s -> true)
                 .orElse(false);
+    }
+
+    public Provider<Boolean> isTestSelectionEnabled() {
+        // Predictive test selection is enabled if:
+        // an environment variable is explicitly configured and set to true
+        // or a system property is explicitly configured and set to true
+        // or it's a local build
+        return providers.environmentVariable("PREDICTIVE_TEST_SELECTION")
+                .orElse(providers.systemProperty("predictiveTestSelection"))
+                .map(it -> {
+                    if (it.trim().length() > 0) {
+                        return Boolean.parseBoolean(it);
+                    }
+                    return false;
+                })
+                .orElse(isNotGithubAction());
     }
 
     public void duringMigration(Runnable action) {

--- a/src/main/java/io/micronaut/build/MicronautGradleEnterprisePlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautGradleEnterprisePlugin.java
@@ -35,6 +35,10 @@ import java.lang.reflect.InvocationTargetException;
 import static io.micronaut.build.ProviderUtils.envOrSystemProperty;
 
 public class MicronautGradleEnterprisePlugin implements Plugin<Settings> {
+    private static final String[] SAFE_TO_LOG_ENV_VARIABLES = new String[] {
+            "PREDICTIVE_TEST_SELECTION"
+    };
+
     @Override
     public void apply(Settings settings) {
         PluginManager pluginManager = settings.getPluginManager();
@@ -89,6 +93,18 @@ public class MicronautGradleEnterprisePlugin implements Plugin<Settings> {
                     });
                 }
             });
+            BuildEnvironment buildEnvironment = new BuildEnvironment(providers);
+            if (Boolean.TRUE.equals(buildEnvironment.isTestSelectionEnabled().get())) {
+                ge.getBuildScan().tag("Predictive Test Selection");
+            }
+            captureSafeEnvironmentVariables(ge);
+        }
+    }
+
+    private void captureSafeEnvironmentVariables(GradleEnterpriseExtension ge) {
+        for (String variable : SAFE_TO_LOG_ENV_VARIABLES) {
+            String value = System.getenv(variable);
+            ge.getBuildScan().value("env." + variable, value == null ? "<undefined>" : value);
         }
     }
 


### PR DESCRIPTION
This will let project which do not use the "common plugin" code to
enable test selection. This is typically the case of the Micronaut
Gradle plugin which isn't a typical Micronaut library.