### PR TITLE
Upgrade test distribution plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     }
 
     implementation 'com.gradle:gradle-enterprise-gradle-plugin:3.10'
-    implementation 'com.gradle.enterprise:test-distribution-gradle-plugin:2.3'
+    implementation 'com.gradle.enterprise:test-distribution-gradle-plugin:2.3.1'
     implementation 'org.nosphere.gradle.github:gradle-github-actions-plugin:1.3.2'
     implementation 'com.gradle:common-custom-user-data-gradle-plugin:1.6.5'
     implementation 'org.gradle:test-retry-gradle-plugin:1.3.2'

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -108,23 +108,6 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
             }
         }
 
-        def testSelectionEnabled = micronautBuildExtension.environment.isTestSelectionEnabled()
-        project.dependencies {
-            testImplementation(testSelectionEnabled.map { enabled ->
-                if (enabled) {
-                    platform('org.junit:junit-bom') {
-                        version {
-                            require '[5.8,)'
-                            prefer '5.8.2'
-                        }
-                        because "Predictive test selection requires JUnit 5.8+"
-                    }
-                } else {
-                    null
-                }
-            })
-        }
-
         project.tasks.withType(Test).configureEach {
             jvmArgs '-Duser.country=US'
             jvmArgs '-Duser.language=en'
@@ -141,7 +124,7 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
                 failOnPassedAfterRetry.set(false)
             }
             predictiveSelection {
-                enabled = testSelectionEnabled
+                enabled = micronautBuildExtension.environment.isTestSelectionEnabled()
             }
         }
 


### PR DESCRIPTION
This fixes a bug which prevented test selection to work properly with JUnit 5.7.
We can now remove the constraint, which should avoid cache misses when a build
is executed on CI and that test selection is enabled locally.

FYI @leonard84

