### PR TITLE
Improve version property lookup

### DIFF
--- a/src/functionalTest/gradle-projects/test-micronaut-module/gradle.properties
+++ b/src/functionalTest/gradle-projects/test-micronaut-module/gradle.properties
@@ -1,10 +1,5 @@
 projectVersion=1.0.0-SNAPSHOT
 projectGroup=io.micronaut.project-template
-micronautDocsVersion=2.0.0
-micronautVersion=3.2.3
-micronautTestVersion=3.0.5
-groovyVersion=3.0.9
-spockVersion=2.0-groovy-3.0
 
 title=Micronaut project-template
 projectDesc=TODO

--- a/src/functionalTest/gradle-projects/test-micronaut-module/gradle/libs.versions.toml
+++ b/src/functionalTest/gradle-projects/test-micronaut-module/gradle/libs.versions.toml
@@ -1,0 +1,6 @@
+[versions]
+micronaut = "3.2.3"
+micronaut-test = "3.0.5"
+micronaut-docs = "2.0.0"
+groovy = "3.0.9"
+spock = "2.0-groovy-3.0"

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -1,10 +1,10 @@
 package io.micronaut.build
 
+
 import org.gradle.api.GradleException
-import org.gradle.api.Project
 import org.gradle.api.Plugin
+import org.gradle.api.Project
 import org.gradle.api.artifacts.DependencyResolveDetails
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.compile.JavaCompile
@@ -13,6 +13,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.tasks.Jar
 import org.groovy.lang.groovydoc.tasks.GroovydocTask
 
+import static io.micronaut.build.util.VersionHandling.versionOrDefault
 /**
  * Micronaut internal Gradle plugin. Not intended to be used in user's projects.
  */
@@ -33,16 +34,8 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
     private void configureDependencies(Project project, MicronautBuildExtension micronautBuild) {
         project.afterEvaluate {
 
-            String micronautVersion = project.findProperty("micronautVersion")
-            String groovyVersion = project.findProperty("groovyVersion")
-            if (groovyVersion == null) {
-                groovyVersion = project.extensions.findByType(VersionCatalogsExtension)
-                        ?.find("libs")
-                        ?.map {
-                            it.findVersion("managed.groovy").get().requiredVersion
-                        }
-                        ?.orElse("undefined") ?: "no_version_catalog"
-            }
+            String micronautVersion = versionOrDefault(project, "micronaut")
+            String groovyVersion = versionOrDefault(project, "groovy")
 
             project.configurations {
                 documentation

--- a/src/main/groovy/io/micronaut/build/MicronautModulePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautModulePlugin.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 
+import static io.micronaut.build.util.VersionHandling.versionOrDefault
 /**
  * Configures a project as a typical Micronaut module project,
  * which implies that it's a library aimed at being processed
@@ -22,12 +23,12 @@ class MicronautModulePlugin implements Plugin<Project> {
     private static Dependency configureStandardDependencies(Project project) {
         project.dependencies.with {
             add("annotationProcessor", "io.micronaut:micronaut-inject-java")
-            add("annotationProcessor", "io.micronaut.docs:micronaut-docs-asciidoc-config-props:${project.findProperty('micronautDocsVersion')}")
+            add("annotationProcessor", "io.micronaut.docs:micronaut-docs-asciidoc-config-props:${versionOrDefault(project, 'micronaut-docs')}")
 
             add("api", "io.micronaut:micronaut-inject")
 
-            add("testImplementation", "org.spockframework:spock-core:${project.findProperty('spockVersion')}")
-            add("testImplementation", "io.micronaut.test:micronaut-test-spock:${project.findProperty('micronautTestVersion')}")
+            add("testImplementation", "org.spockframework:spock-core:${versionOrDefault(project, 'spock')}")
+            add("testImplementation", "io.micronaut.test:micronaut-test-spock:${versionOrDefault(project, 'micronaut-test')}")
         }
     }
 }

--- a/src/main/groovy/io/micronaut/build/util/VersionHandling.java
+++ b/src/main/groovy/io/micronaut/build/util/VersionHandling.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.util;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.VersionCatalogsExtension;
+import org.gradle.api.artifacts.VersionConstraint;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class VersionHandling {
+    /**
+     * Returns a version defined in the catalog. If not found,
+     * looks for a property (typically declared in gradle.properties).
+     */
+    public static String versionOrDefault(
+            Project project,
+            String alias) {
+        VersionCatalogsExtension catalogs = project.getExtensions().findByType(VersionCatalogsExtension.class);
+        if (catalogs == null) {
+            return projectProperty(project, alias);
+        }
+        return catalogs.find("libs")
+                .flatMap(catalog -> {
+                    Optional<VersionConstraint> version = catalog.findVersion(alias);
+                    if (version.isPresent()) {
+                        return version;
+                    }
+                    return catalog.findVersion("managed." + alias);
+                })
+                .map(VersionConstraint::getRequiredVersion)
+                .orElseGet(() -> projectProperty(project, alias));
+    }
+
+    private static String projectProperty(Project p, String alias) {
+        String[] components = alias.split("[.-_]");
+        String propertyName = IntStream.range(0, components.length)
+                .mapToObj(i -> {
+                    if (i == 0) {
+                        return components[i];
+                    } else {
+                        String c = components[i];
+                        return Character.toUpperCase(c.charAt(0)) + c.substring(1).toLowerCase();
+                    }
+                })
+                .collect(Collectors.joining(""));
+        Object projectProp = p.findProperty(propertyName + "Version");
+        if (projectProp != null) {
+            return String.valueOf(projectProp);
+        }
+        return "";
+    }
+}

--- a/src/main/java/io/micronaut/build/MicronautBuildSettingsPlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildSettingsPlugin.java
@@ -25,7 +25,7 @@ public class MicronautBuildSettingsPlugin implements Plugin<Settings> {
 
     @Override
     public void apply(Settings settings) {
-        settings.getExtensions().create("micronautBuild", MicronautBuildSettingsExtension.class);
+        settings.getExtensions().create("micronautBuild", MicronautBuildSettingsExtension.class, settings);
     }
 
 }


### PR DESCRIPTION
This commit improves how Micronaut versions are read, so that we can
consistently use version catalogs. Previously to this change, some
versions still had to be declared in `gradle.properties`, which was
inconsistent with the use of the version catalog for other dependencies.

With this change, it is possible to declare everything in the catalog,
including the special versions `micronaut`, `micronaut-docs`, `micronaut-test`,
`groovy` and `spock`.

This change in made in a compatible way: if the version is defined in the catalog
it will be fetched from it, otherwise it will get the old version from the
gradle properties file.

This is a pre-requisite to updating the project template to use version catalogs.
