### PR TITLE
Expose `micronautVersion` property to build scripts

### DIFF
--- a/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
@@ -21,6 +21,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.invocation.Gradle;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -42,6 +43,13 @@ public class MicronautSharedSettingsPlugin implements Plugin<Settings> {
         pluginManager.apply(MicronautGradleEnterprisePlugin.class);
         applyPublishingPlugin(settings);
         assertUniqueProjectNames(settings);
+        MicronautBuildSettingsExtension buildSettingsExtension = settings.getExtensions().findByType(MicronautBuildSettingsExtension.class);
+        settings.getGradle().beforeProject(p -> {
+            ExtraPropertiesExtension extraProperties = p.getExtensions().getExtraProperties();
+            if (!extraProperties.has("micronautVersion")) {
+                extraProperties.set("micronautVersion", buildSettingsExtension.getMicronautVersion());
+            }
+        });
     }
 
     private void assertUniqueProjectNames(Settings settings) {

--- a/src/main/java/io/micronaut/build/util/VersionHandling.java
+++ b/src/main/java/io/micronaut/build/util/VersionHandling.java
@@ -47,7 +47,7 @@ public class VersionHandling {
                 .orElseGet(() -> projectProperty(project, alias));
     }
 
-    private static String projectProperty(Project p, String alias) {
+    private static String propertyNameFor(String alias) {
         String[] components = alias.split("[.-_]");
         String propertyName = IntStream.range(0, components.length)
                 .mapToObj(i -> {
@@ -59,7 +59,11 @@ public class VersionHandling {
                     }
                 })
                 .collect(Collectors.joining(""));
-        Object projectProp = p.findProperty(propertyName + "Version");
+        return propertyName + "Version";
+    }
+
+    private static String projectProperty(Project p, String alias) {
+        Object projectProp = p.findProperty(propertyNameFor(alias));
         if (projectProp != null) {
             return String.valueOf(projectProp);
         }


### PR DESCRIPTION
If a project uses a version catalog, the `micronautVersion` property isn't
exposed to build scripts anymore, which might be a problem for some plugins
(like the Micronaut application plugin) which need it to be set.