### PR TITLE
Fix mapping from catalog version alias to property name

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBomPlugin.java
+++ b/src/main/groovy/io/micronaut/build/MicronautBomPlugin.java
@@ -89,6 +89,7 @@ public abstract class MicronautBomPlugin implements Plugin<Project> {
         plugins.apply(VersionCatalogPlugin.class);
         plugins.apply(MicronautBuildExtensionPlugin.class);
         plugins.apply(MicronautPublishingPlugin.class);
+        plugins.apply(MicronautDependencyResolutionConfigurationPlugin.class);
         MicronautBomExtension bomExtension = project.getExtensions().create("micronautBom", MicronautBomExtension.class);
         bomExtension.getPublishCatalog().convention(true);
         bomExtension.getIncludeBomInCatalog().convention(true);
@@ -100,7 +101,6 @@ public abstract class MicronautBomPlugin implements Plugin<Project> {
         bomExtension.getExcludedInlinedAliases().convention(Collections.emptySet());
         bomExtension.getInferProjectsToInclude().convention(true);
         configureBOM(project, bomExtension);
-        project.getRepositories().mavenCentral();
     }
 
     private static String nameOf(Node n) {

--- a/src/main/java/io/micronaut/build/util/VersionHandling.java
+++ b/src/main/java/io/micronaut/build/util/VersionHandling.java
@@ -48,7 +48,7 @@ public class VersionHandling {
     }
 
     private static String propertyNameFor(String alias) {
-        String[] components = alias.split("[.-_]");
+        String[] components = alias.split("[.\\-_]");
         String propertyName = IntStream.range(0, components.length)
                 .mapToObj(i -> {
                     if (i == 0) {

--- a/src/test/groovy/io/micronaut/build/util/VersionHandlingTest.groovy
+++ b/src/test/groovy/io/micronaut/build/util/VersionHandlingTest.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.build.util
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class VersionHandlingTest extends Specification {
+    def "defaults to Gradle properties when looking for versions"() {
+        def project = ProjectBuilder.builder().build()
+        project.ext.micronautVersion = "1.0.0"
+        project.ext.micronautDocsVersion = "1.5.0"
+
+        when:
+        def version = VersionHandling.versionOrDefault(project, alias)
+
+        then:
+        version == expectedVersion
+
+        where:
+        alias            | expectedVersion
+        "micronaut"      | "1.0.0"
+        "micronaut-docs" | "1.5.0"
+        "unknown"        | ""
+    }
+}


### PR DESCRIPTION
Before this change, `micronaut-docs` was incorrectly mapped so
the property being looked for was `micronaut-docsVersion` instead
of `micronautDocsVersion`.

This fixes a weird dependency resolution error which was hidden behind a "repositories setup" problem: https://ge.micronaut.io/s/ferz7p7ktjevq/failure#1

The actual problem was a missing dependency version.