### PR TITLE
Fix `hasProperty(micronautVersion)`

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -70,7 +70,7 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
                 documentation "org.codehaus.groovy:groovy-templates:$groovyVersion"
                 documentation "org.codehaus.groovy:groovy-dateutil:$groovyVersion"
 
-                if (project.hasProperty('micronautVersion')) {
+                if (micronautVersion) {
                     testCompileOnly "io.micronaut:micronaut-inject-groovy:${micronautVersion}"
                 }
 


### PR DESCRIPTION
This commit fixes `micronaut-build` application on `micronaut-core`:
there was a test which verified if the `micronautVersion` property was
set, but since we automatically create this property now, this was
causing a dependency to be injected automatically when it shouldn't.