### PR TITLE
map developmentOnly to provided in maven

### DIFF
--- a/src/main/groovy/io/micronaut/docs/BuildDependencyMacro.groovy
+++ b/src/main/groovy/io/micronaut/docs/BuildDependencyMacro.groovy
@@ -122,7 +122,7 @@ class BuildDependencyMacro extends InlineMacroProcessor implements ValueAtAttrib
             case 'testRuntimeOnly':
             case 'testImplementation':
                 return 'test'
-            case 'developmentOnly'
+            case 'developmentOnly':
             case 'compileOnly': 
                 return 'provided'
             case 'runtimeOnly': return 'runtime'

--- a/src/main/groovy/io/micronaut/docs/BuildDependencyMacro.groovy
+++ b/src/main/groovy/io/micronaut/docs/BuildDependencyMacro.groovy
@@ -122,7 +122,9 @@ class BuildDependencyMacro extends InlineMacroProcessor implements ValueAtAttrib
             case 'testRuntimeOnly':
             case 'testImplementation':
                 return 'test'
-            case 'compileOnly': return 'provided'
+            case 'developmentOnly'
+            case 'compileOnly': 
+                return 'provided'
             case 'runtimeOnly': return 'runtime'
             default: return s
         }


### PR DESCRIPTION
Context: https://github.com/micronaut-projects/micronaut-starter/pull/1215

We are using `developmentOnly` scope in the MicroStream module docs.