### PR TITLE
Fix spotless dependency

### DIFF
--- a/src/main/java/io/micronaut/build/MicronautQualityChecksParticipantPlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautQualityChecksParticipantPlugin.java
@@ -38,7 +38,9 @@ public class MicronautQualityChecksParticipantPlugin implements Plugin<Project> 
 
             p.getTasks().named("checkstyleTest").configure(task -> task.setEnabled(false));
             p.getTasks().named("checkstyleMain").configure(task -> {
-                task.dependsOn("spotlessCheck");
+                p.getPluginManager().withPlugin("com.diffplug.spotless", unused ->
+                        task.dependsOn("spotlessCheck")
+                );
                 project.getRootProject().getPluginManager().withPlugin("org.sonarqube", sq -> {
                     project.getRootProject().getTasks().named("sonarqube").configure(t -> t.dependsOn(task));
                 });


### PR DESCRIPTION
I am not quite sure why we have a dependency between checkstyle and
spotless. However since it's there, let's fix it so that it works
properly in case the spotless plugin isn't applied.

This commit fixes the case where the code quality plugin is applied
on a project which doesn't apply the spotless plugin, which might
be the case for "test projects" for example.