### PR TITLE
Fix baseline reading

### DIFF
--- a/src/test/groovy/io/micronaut/build/compat/VersionModelTest.groovy
+++ b/src/test/groovy/io/micronaut/build/compat/VersionModelTest.groovy
@@ -13,6 +13,8 @@ class VersionModelTest extends Specification {
         v("1.0") < v("1.0.1")
         v("0.9") < v("0.10")
         v("0.1") < v("1.3.2")
+        v("3.4.5") < v("3.5.0")
+        v("3.5.0") > v("3.4.5")
     }
 
     static VersionModel v(String version) {


### PR DESCRIPTION
The way the baseline reading was wired made it so that the convention
value was set _before_ the file was actually created. In order to
workaround the problem, we now use a `fileContents` provider.