### PR TITLE
Fix binary compatibility checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,6 @@ plugins {
 version project.projectVersion
 group "io.micronaut.build.internal"
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
-    }
-}
-
 repositories {
     mavenCentral()
     gradlePluginPortal()
@@ -38,9 +32,6 @@ configurations {
 }
 
 tasks.withType(Test).configureEach {
-    javaLauncher.set(javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(8)
-    })
     useJUnitPlatform()
 }
 

--- a/src/main/groovy/io/micronaut/build/compat/JavaBridgeAndSyntheticRule.java
+++ b/src/main/groovy/io/micronaut/build/compat/JavaBridgeAndSyntheticRule.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.compat;
+
+import japicmp.model.BridgeModifier;
+import japicmp.model.JApiClass;
+import japicmp.model.JApiCompatibility;
+import japicmp.model.JApiMethod;
+import japicmp.model.JApiModifier;
+import japicmp.model.SyntheticModifier;
+import me.champeau.gradle.japicmp.report.Severity;
+import me.champeau.gradle.japicmp.report.Violation;
+import me.champeau.gradle.japicmp.report.ViolationTransformer;
+
+import java.util.Optional;
+
+/**
+ * This rule turns errors on internal Java bridge methods into warnings
+ * and ignores synthetic classes.
+ */
+public class JavaBridgeAndSyntheticRule implements ViolationTransformer {
+
+    @Override
+    public Optional<Violation> transform(String type, Violation violation) {
+        JApiCompatibility violationMember = violation.getMember();
+        if (violationMember instanceof JApiMethod) {
+            JApiMethod method = (JApiMethod) violationMember;
+            JApiModifier<BridgeModifier> bridgeModifier = method.getBridgeModifier();
+            if (bridgeModifier != null) {
+                return Optional.of(violation.withSeverity(Severity.warning));
+            }
+        }
+        if (violationMember instanceof JApiClass) {
+            JApiClass clazz = (JApiClass) violationMember;
+            JApiModifier<SyntheticModifier> bridgeModifier = clazz.getSyntheticModifier();
+            if (bridgeModifier != null) {
+                return Optional.of(violation.withSeverity(Severity.warning));
+            }
+        }
+        return Optional.of(violation);
+    }
+
+}

--- a/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
+++ b/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
@@ -77,6 +77,7 @@ public class MicronautBinaryCompatibilityPlugin implements Plugin<Project> {
                         report.getTitle().set(baseline.map(version -> "Binary compatibility report for Micronaut " + project.getName() + " " + project.getVersion() + " against " + version));
                         report.getAddDefaultRules().set(true);
                         report.addViolationTransformer(InternalMicronautTypeRule.class);
+                        report.addViolationTransformer(JavaBridgeAndSyntheticRule.class);
                         report.addRule(InternalAnnotationCollectorRule.class);
                         report.addPostProcessRule(InternalAnnotationPostProcessRule.class);
                     });


### PR DESCRIPTION
This commit fixes a couple of issues with the binary compatibility
checks:

- first, the "baseline" task was cacheable, but didn't take into
account the actual contents of the JSON file returned by GH releases.
This means that if a release was made in between, we could compare
against an older baseline than expected.
- second, this commit introduces a rule to ignore Java bridge methods
and synthetic classes

The reason for the 2d change is that we moved from releasing with Java 8,
to releasing with Java 11 and targetting Java 8 bytecode. However the
Java 11 compiler may generate different synthetic code than the Java 8
one. So we simply ignore those internal implementation details.