### PR TITLE
Authenticate with GitHub when fetching a baseline

### DIFF
--- a/src/main/java/io/micronaut/build/compat/FindBaselineTask.java
+++ b/src/main/java/io/micronaut/build/compat/FindBaselineTask.java
@@ -62,6 +62,9 @@ public abstract class FindBaselineTask extends DefaultTask {
             HttpURLConnection con = (HttpURLConnection) url.openConnection();
             con.setRequestMethod("GET");
             con.setRequestProperty("Accept", "application/vnd.github.v3+json");
+            if (System.getenv("GITHUB_TOKEN") != null) {
+                con.setRequestProperty("Authorization", "Bearer " + System.getenv("GITHUB_TOKEN"));
+            }
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             try (ReadableByteChannel rbc = Channels.newChannel(con.getInputStream()); WritableByteChannel wbc=Channels.newChannel(out)){
                 ByteBuffer buffer = ByteBuffer.allocateDirect(16 * 1024);


### PR DESCRIPTION
I believe we are being rate-limited on finding a baseline for jacpi.

This change adds Bearer authentication to the request if GITHUB_TOKEN is defined in the environment.

This will increase our rate limit