### PR TITLE
Remove the dependency updates plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     // TODO: upgrade to new asciidoctor
     implementation 'org.asciidoctor:asciidoctorj:2.5.5'
     implementation "io.spring.nohttp:nohttp-gradle:0.0.10"
-    implementation "com.github.ben-manes:gradle-versions-plugin:0.42.0"
     implementation "com.diffplug.spotless:spotless-plugin-gradle:6.11.0"
     implementation "com.adarshr:gradle-test-logger-plugin:3.2.0"
     implementation "io.github.gradle-nexus:publish-plugin:1.1.0"

--- a/src/main/groovy/io/micronaut/build/DeprecatedTask.java
+++ b/src/main/groovy/io/micronaut/build/DeprecatedTask.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+
+public abstract class DeprecatedTask extends DefaultTask {
+    @Input
+    public abstract Property<String> getMessage();
+
+    @Optional
+    @Input
+    public abstract Property<String> getReplacement();
+
+    @TaskAction
+    public void logDeprecation() {
+        String message = getMessage().get();
+        String replacement = getReplacement().getOrNull();
+        if (replacement != null) {
+            message += ". Use " + replacement + " instead.";
+        }
+        getLogger().warn(message);
+    }
+}

--- a/src/main/groovy/io/micronaut/build/MicronautDependencyUpdatesPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautDependencyUpdatesPlugin.groovy
@@ -1,20 +1,16 @@
 package io.micronaut.build
 
+import groovy.transform.CompileStatic
 import io.micronaut.build.catalogs.MicronautVersionCatalogUpdatePlugin
-import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.plugins.quality.Checkstyle
-
 /**
  * Micronaut internal Gradle plugin. Not intended to be used in user's projects.
  */
+@CompileStatic
 class MicronautDependencyUpdatesPlugin implements Plugin<Project> {
 
-
-    public static final String GRADLE_VERSIONS_PLUGIN = "com.github.ben-manes.versions"
-    public static final String USE_LATEST_VERSIONS_PLUGIN = "se.patrikerdes.use-latest-versions"
 
     @Override
     void apply(Project project) {
@@ -25,8 +21,6 @@ class MicronautDependencyUpdatesPlugin implements Plugin<Project> {
             }
             return
         }
-        project.apply plugin: GRADLE_VERSIONS_PLUGIN
-        project.apply plugin: USE_LATEST_VERSIONS_PLUGIN
 
         MicronautBuildExtension micronautBuildExtension = project.extensions.getByType(MicronautBuildExtension)
 
@@ -37,47 +31,14 @@ class MicronautDependencyUpdatesPlugin implements Plugin<Project> {
         }
 
         project.with {
-            tasks.named("dependencyUpdates") {
-                onlyIf {
-                    gradle.taskGraph.hasTask(":useLatestVersions")
-                }
-                checkForGradleUpdate = true
-                gradleReleaseChannel = "current"
-                checkConstraints = true
-                revision = "release"
-                rejectVersionIf { mod ->
-                    mod.candidate.version ==~
-                            micronautBuildExtension.dependencyUpdatesPattern ||
-                            ['alpha', 'beta', 'milestone', 'rc', 'cr', 'm', 'preview', 'b', 'ea'].any { qualifier ->
-                                mod.candidate.version ==~ /(?i).*[.-]$qualifier[.\d-+]*/
-                            } ||
-                            mod.candidate.group == 'io.micronaut' // managed by the micronaut version
-                }
-
-                outputFormatter = { result ->
-                    if (!result.outdated.dependencies.isEmpty()) {
-                        def upgradeVersions = result.outdated.dependencies
-                        if (!upgradeVersions.isEmpty()) {
-                            println "\nThe following dependencies have later ${revision} versions:"
-                            upgradeVersions.each { dep ->
-                                def currentVersion = dep.version
-                                println " - ${dep.group}:${dep.name} [${currentVersion} -> ${dep.available[revision]}]"
-                                if (dep.projectUrl != null) {
-                                    println "     ${dep.projectUrl}"
-                                }
-                            }
-                            throw new GradleException('Abort, there are dependencies to update. Run ./gradlew useLatestVersions to update them in place')
-                        }
-                    }
-                }
+            tasks.register("dependencyUpdates", DeprecatedTask) {
+                it.message.set("The dependencyUpdates task is scheduled for removal")
+                it.replacement.set("Renovatebot")
             }
 
-            tasks.named("useLatestVersions") {
-                updateRootProperties = true
-            }
-
-            tasks.withType(Checkstyle).configureEach {
-                it.dependsOn('dependencyUpdates')
+            tasks.register("useLatestVersions", DeprecatedTask) {
+                it.message.set("The useLatestVersions task is scheduled for removal")
+                it.replacement.set("Renovatebot")
             }
         }
     }


### PR DESCRIPTION
We don't use that plugin anymore. In order to make sure workflows still work in case they are still using this task, a `DeprecatedTask` has been added, which warns to remove the use of the task.