### PR TITLE
Default to Java 17

### DIFF
--- a/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
+++ b/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
@@ -1,0 +1,44 @@
+package io.micronaut.build
+
+class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
+
+    void "defaults to Java 17"() {
+        given:
+        withSample("test-micronaut-module")
+
+        file("subproject1/build.gradle") << """
+            tasks.register("printJavaVersion") {
+                doLast {
+                    println "Java version: \${micronautBuild.javaVersion.get()}"
+                }
+            }
+        """
+
+        when:
+        run 'printJavaVersion'
+
+        then:
+        outputContains "Java version: 17"
+    }
+
+   void "warns if using #property compatibility"() {
+        given:
+        withSample("test-micronaut-module")
+
+        file("subproject1/build.gradle") << """
+            micronautBuild.$property = "8"
+        """
+
+        when:
+        run 'help'
+
+        then:
+        outputContains """The "sourceCompatibility" and "targetCompatibility" properties are deprecated.
+Please use "micronautBuild.javaVersion" instead.
+You can do this directly in the project, or, better, in a convention plugin if it exists."""
+
+       where:
+       property << ["sourceCompatibility", "targetCompatibility"]
+    }
+
+}

--- a/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -2,14 +2,17 @@ package io.micronaut.build;
 
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
-import javax.inject.Inject;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 
+import javax.inject.Inject;
+
 public abstract class MicronautBuildExtension {
 
   public static final String DEFAULT_DEPENDENCY_UPDATES_PATTERN = "(?i).+(-|\\.?)(b|M|RC|Dev)\\d?.*";
+  public static final int DEFAULT_JAVA_VERSION = 17;
+  public static final String DEFAULT_CHECKSTYLE_VERSION = "8.33";
 
   private final BuildEnvironment environment;
 
@@ -25,9 +28,8 @@ public abstract class MicronautBuildExtension {
     this.environment = buildEnvironment;
     this.compileOptions = getObjects().newInstance(MicronautCompileOptions.class);
 
-    getSourceCompatibility().convention("1.8");
-    getTargetCompatibility().convention("1.8");
-    getCheckstyleVersion().convention("8.33");
+    getJavaVersion().convention(DEFAULT_JAVA_VERSION);
+    getCheckstyleVersion().convention(DEFAULT_CHECKSTYLE_VERSION);
     getDependencyUpdatesPattern().convention(DEFAULT_DEPENDENCY_UPDATES_PATTERN);
     getEnforcedPlatform().convention(false);
     getEnableProcessing().convention(false);
@@ -47,13 +49,24 @@ public abstract class MicronautBuildExtension {
   }
 
   /**
-   * The default source compatibility
+   * The version of Java this project is supporting. This is equivalent
+   * to setting the Java language version on the Java extension.
+   * @return the java version for this project
    */
+  public abstract Property<Integer> getJavaVersion();
+
+  /**
+   * The default source compatibility
+   * @deprecated prefer using {@link #getJavaVersion()} instead
+   */
+  @Deprecated
   public abstract Property<String> getSourceCompatibility();
 
   /**
    * The default target compatibility
+   * @deprecated prefer using {@link #getJavaVersion()} instead
    */
+  @Deprecated
   public abstract Property<String> getTargetCompatibility();
 
   /**


### PR DESCRIPTION
This commit makes the build plugin configure Java 17 by default. It deprecates the use of `sourceCompatibility` and `targetCompatibility` on the `micronautBuild` extension, in favor of using Gradle's toolchain support instead.

If a project is not ready for Java 17, which is likely to happen for current Micronaut modules, it is possible to override the default Java version by setting the `micronautBuild.javaVersion` property.

If a project is _today_ using the `micronautBuild.sourceCompatibility` property (or `targetCompatibility`), then toolchain support isn't used, and a deprecation warning is issued during the build.