### PR TITLE
Include a pom.xml file into the published jars

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.groovy
@@ -137,9 +137,10 @@ class MicronautPublishingPlugin implements Plugin<Project> {
 
                     }
                     publications {
+                        String aid = "micronaut-" + project.name.substring(project.name.indexOf('/') + 1)
                         if (project.extensions.findByType(PublishingExtension).publications.empty) {
                             maven(MavenPublication) { publication ->
-                                artifactId( "micronaut-" + project.name.substring(project.name.indexOf('/') + 1) )
+                                artifactId( aid )
 
                                 if (!project.name.endsWith("bom")) {
                                     versionMapping {
@@ -234,6 +235,17 @@ class MicronautPublishingPlugin implements Plugin<Project> {
                                     }
                                 }
 
+                            }
+                        }
+                        // Include a pom.xml file into the jar
+                        // so that automated vulnerability scanners are happy
+                        tasks.withType(Jar).configureEach {
+                            if (it.name in ['jar', 'shadowJar']) {
+                                into("META-INF/maven/${project.group}/${aid}") {
+                                    from(tasks.named("generatePomFileForMavenPublication")) {
+                                        rename("pom-default.xml", "pom.xml")
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This commit adds the inclusion of the generated `pom.xml` file into the `META-INF/maven/group.id/artifact.id` directory of the published jars. While this file can be fetched externally, some vulnerability scanners actually look for this file.

It doesn't guarantee that users would use the exact same version of dependencies, but it is consistent with what Maven would do, for the better or worse.