### PR TITLE
Add native-image.properties generator

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBasePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBasePlugin.groovy
@@ -18,6 +18,7 @@ package io.micronaut.build
 import groovy.transform.CompileStatic
 import io.micronaut.build.docs.AggregatedJavadocParticipantPlugin
 import io.micronaut.build.docs.ConfigurationPropertiesPlugin
+import io.micronaut.build.graalvm.NativeImageSupportPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 /**
@@ -34,6 +35,7 @@ class MicronautBasePlugin implements Plugin<Project> {
         project.pluginManager.apply(MicronautBuildExtensionPlugin)
         project.pluginManager.apply(ConfigurationPropertiesPlugin)
         project.pluginManager.apply(AggregatedJavadocParticipantPlugin)
+        project.pluginManager.apply(NativeImageSupportPlugin)
     }
 
     private void configureProjectVersion(Project project) {

--- a/src/main/groovy/io/micronaut/build/graalvm/NativeImagePropertiesExtension.java
+++ b/src/main/groovy/io/micronaut/build/graalvm/NativeImagePropertiesExtension.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.graalvm;
+
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+
+/**
+ * Lets the user configure generation of a native-image.properties
+ * file.
+ */
+public interface NativeImagePropertiesExtension {
+    /**
+     * Determines if native-image.properties file should be generated.
+     * @return true if the file should be generated
+     */
+    Property<Boolean> getEnabled();
+
+    /**
+     * The content of the native-image.properties file to generate.
+     * This cannot be used if any of the other convenience properties are used.
+     * @return the contents of the native image properties file
+     */
+    Property<String> getContents();
+
+    /**
+     * The list of classes/packages to initialize at runtime
+     * @return the list of classes/packages to initialize at runtime
+     */
+    ListProperty<String> getInitializeAtRuntime();
+
+    /**
+     * The list of classes/packages to initialize at build time
+     * @return the list of classes/packages to initialize at build time
+     */
+    ListProperty<String> getInitializeAtBuildtime();
+
+    /**
+     * The list of features to enable
+     * @return the list of features
+     */
+    ListProperty<String> getFeatures();
+}

--- a/src/main/groovy/io/micronaut/build/graalvm/NativeImageSupportPlugin.java
+++ b/src/main/groovy/io/micronaut/build/graalvm/NativeImageSupportPlugin.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.graalvm;
+
+import io.micronaut.build.MicronautBuildExtension;
+import io.micronaut.build.MicronautBuildExtensionPlugin;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.plugins.PluginManager;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskProvider;
+
+public class NativeImageSupportPlugin implements Plugin<Project> {
+
+    public static final String NATIVE_IMAGE_PROPERTIES_EXTENSION_NAME = "nativeImageProperties";
+    public static final String GENERATE_NATIVE_IMAGE_PROPERTIES_TASK_NAME = "generateNativeImageProperties";
+
+    @Override
+    public void apply(Project project) {
+        PluginManager pluginManager = project.getPluginManager();
+        pluginManager.apply(MicronautBuildExtensionPlugin.class);
+        MicronautBuildExtension micronautBuildExtension = project.getExtensions().findByType(MicronautBuildExtension.class);
+        NativeImagePropertiesExtension nativeImageExtension = ((ExtensionAware) micronautBuildExtension).getExtensions().create(NATIVE_IMAGE_PROPERTIES_EXTENSION_NAME, NativeImagePropertiesExtension.class);
+        nativeImageExtension.getEnabled().convention(false);
+        TaskProvider<NativePropertiesWriter> generateNativeImageProperties = project.getTasks().register(GENERATE_NATIVE_IMAGE_PROPERTIES_TASK_NAME, NativePropertiesWriter.class, task -> {
+            task.onlyIf(t -> nativeImageExtension.getEnabled().get());
+            task.getOutputDirectory().convention(project.getLayout().getBuildDirectory().dir("generated/resources/native-image-properties"));
+            task.getContents().convention(nativeImageExtension.getContents());
+            task.getInitializeAtRuntime().convention(nativeImageExtension.getInitializeAtRuntime());
+            task.getInitializeAtBuildtime().convention(nativeImageExtension.getInitializeAtBuildtime());
+            task.getFeatures().convention(nativeImageExtension.getFeatures());
+            task.getGroupId().convention(project.getProviders().provider(() -> String.valueOf(project.getGroup())));
+            task.getArtifactId().convention(project.getProviders().provider(() -> "micronaut-" + project.getName()));
+        });
+        pluginManager.withPlugin("java", unused -> {
+            SourceSetContainer sourceSets = project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets();
+            sourceSets.getByName("main").getResources().srcDir(generateNativeImageProperties);
+        });
+    }
+}

--- a/src/main/groovy/io/micronaut/build/graalvm/NativePropertiesWriter.java
+++ b/src/main/groovy/io/micronaut/build/graalvm/NativePropertiesWriter.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.graalvm;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@CacheableTask
+public abstract class NativePropertiesWriter extends DefaultTask {
+
+    private static final String NEWLINE = " \\\n       ";
+
+    /**
+     * The content of the native-image.properties file to generate.
+     * This cannot be used if any of the other convenience properties are used.
+     * @return the contents of the native image properties file
+     */
+    @Input
+    @Optional
+    abstract Property<String> getContents();
+
+    /**
+     * The list of classes/packages to initialize at runtime
+     * @return the list of classes/packages to initialize at runtime
+     */
+    @Input
+    @Optional
+    abstract ListProperty<String> getInitializeAtRuntime();
+
+     /**
+     * The list of classes/packages to initialize at build time
+     * @return the list of classes/packages to initialize at build time
+     */
+    @Input
+    @Optional
+    abstract ListProperty<String> getInitializeAtBuildtime();
+
+    /**
+     * The list of features to enable
+     * @return the list of features
+     */
+    @Input
+    @Optional
+    abstract ListProperty<String> getFeatures();
+
+    /**
+     * Extra arguments to pass to the native image args. For example,
+     * if you put the key "-H:APIFunctionPrefix" and a value with a single
+     * entry "truffle_isolate_", then we would generate the following argument:
+     * -H:APIFunctionPrefix=truffle_isolate_
+     * @return the extra arguments
+     */
+    @Input
+    @Optional
+    abstract MapProperty<String, List<String>> getExtraArguments();
+
+    @Input
+    abstract Property<String> getGroupId();
+
+    @Input
+    abstract Property<String> getArtifactId();
+
+    /**
+     * The output directory where the native-image.properties file is generated.
+     * @return the output directory
+     */
+    @OutputDirectory
+    abstract DirectoryProperty getOutputDirectory();
+
+    @TaskAction
+    public void generateFile() throws IOException {
+        List<String> initializeAtRuntime = getInitializeAtRuntime().getOrElse(Collections.emptyList());
+        List<String> initializeAtBuildtime = getInitializeAtBuildtime().getOrElse(Collections.emptyList());
+        List<String> features = getFeatures().getOrElse(Collections.emptyList());
+        Map<String, List<String>> extraArguments = getExtraArguments().getOrElse(Collections.emptyMap());
+        Path outputPath = getOutputDirectory().get().getAsFile().toPath();
+        String nativePropertiesPath = "META-INF/native-image/" + getGroupId().get() + "/" + getArtifactId().get() + "/native-image.properties";
+        Files.createDirectories(outputPath.resolve(nativePropertiesPath).getParent());
+        try (BufferedWriter writer = Files.newBufferedWriter(outputPath.resolve(nativePropertiesPath))) {
+            boolean hasContents = getContents().isPresent();
+            if (hasContents) {
+                writer.write(getContents().get());
+                writer.write("\n");
+                if (!initializeAtBuildtime.isEmpty()) {
+                    throw new InvalidUserCodeException("You cannot use both explicit contents and initializeAtBuildtime properties to generate the native-image.properties file");
+                }
+                if (!initializeAtRuntime.isEmpty()) {
+                    throw new InvalidUserCodeException("You cannot use both explicit contents and initializeAtRuntime properties to generate the native-image.properties file");
+                }
+                if (!features.isEmpty()) {
+                    throw new InvalidUserCodeException("You cannot use both explicit contents and features properties to generate the native-image.properties file");
+                }
+                if (!extraArguments.isEmpty()) {
+                    throw new InvalidUserCodeException("You cannot use both explicit contents and extraArguments properties to generate the native-image.properties file");
+                }
+            } else {
+                StringBuilder args = new StringBuilder();
+                if (!initializeAtBuildtime.isEmpty()) {
+                    args.append("--initialize-at-build-time=");
+                    args.append(String.join(",", initializeAtBuildtime));
+                }
+                if (!initializeAtRuntime.isEmpty()) {
+                    if (args.length() > 0) {
+                        args.append(NEWLINE);
+                    }
+                    args.append("--initialize-at-run-time=");
+                    args.append(String.join(",", initializeAtRuntime));
+                }
+                if (!features.isEmpty()) {
+                    if (args.length() > 0) {
+                        args.append(NEWLINE);
+                    }
+                    args.append("--features=");
+                    args.append(String.join(",", features));
+                }
+                if (!extraArguments.isEmpty()) {
+                    for (Map.Entry<String, List<String>> entry : extraArguments.entrySet()) {
+                        if (args.length() > 0) {
+                            args.append(NEWLINE);
+                        }
+                        args.append(entry.getKey()).append("=");
+                        args.append(String.join(",", entry.getValue()));
+                    }
+                }
+                writer.write("Args = ");
+                writer.write(args.toString());
+                writer.write("\n");
+            }
+        }
+    }
+
+}

--- a/src/test/groovy/io/micronaut/build/graalvm/NativeImageSupportPluginTest.groovy
+++ b/src/test/groovy/io/micronaut/build/graalvm/NativeImageSupportPluginTest.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.build.graalvm
+
+import io.micronaut.build.MicronautBuildExtension
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class NativeImageSupportPluginTest extends Specification {
+    def "configures an extension"() {
+        def project = ProjectBuilder.builder().build()
+        project.pluginManager.apply(NativeImageSupportPlugin)
+        def micronautBuildExtension = project.extensions.findByType(MicronautBuildExtension)
+
+        when:
+        def nativeImagePropsExtension = micronautBuildExtension.extensions.findByType(NativeImagePropertiesExtension)
+
+        then:
+        nativeImagePropsExtension.enabled.get() == false
+
+        when:
+        def task = project.tasks.named(NativeImageSupportPlugin.GENERATE_NATIVE_IMAGE_PROPERTIES_TASK_NAME, NativePropertiesWriter)
+
+        then:
+        task.present
+    }
+}

--- a/src/test/groovy/io/micronaut/build/graalvm/NativePropertiesWriterTest.groovy
+++ b/src/test/groovy/io/micronaut/build/graalvm/NativePropertiesWriterTest.groovy
@@ -1,0 +1,102 @@
+package io.micronaut.build.graalvm
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class NativePropertiesWriterTest extends Specification {
+    private Project project
+    private NativePropertiesWriter writer
+    private File nativeImagePropertiesFile
+
+    def setup() {
+        project = ProjectBuilder.builder().build()
+        writer = project.tasks.create("nativePropertiesWriter", NativePropertiesWriter) {
+            groupId.set("io.micronaut")
+            artifactId.set("test")
+            def outputDir = project.layout.buildDirectory.dir("native-image")
+            outputDirectory.set(outputDir)
+            nativeImagePropertiesFile = outputDir.get().file("META-INF/native-image/io.micronaut/test/native-image.properties").asFile
+        }
+    }
+
+    def "can generate a native properties file with explicit contents"() {
+        given:
+        writer.contents.set("Args = --initialize-at-runtime=io.micronaut.Foo")
+
+        when:
+        writer.generateFile()
+
+        then:
+        nativeImagePropertiesFile.text == "Args = --initialize-at-runtime=io.micronaut.Foo\n"
+    }
+
+    def "can generate a native properties file with initialize at runtime"() {
+        given:
+        writer.initializeAtRuntime.addAll("com.Foo", "io.Bar")
+
+        when:
+        writer.generateFile()
+
+        then:
+        nativeImagePropertiesFile.text == "Args = --initialize-at-run-time=com.Foo,io.Bar\n"
+    }
+
+    def "can generate a native properties file with initialize at build time"() {
+        given:
+        writer.initializeAtBuildtime.addAll("com.Foo", "io.Bar")
+
+        when:
+        writer.generateFile()
+
+        then:
+        nativeImagePropertiesFile.text == "Args = --initialize-at-build-time=com.Foo,io.Bar\n"
+    }
+
+    def "can generate a native properties file with features"() {
+        given:
+        writer.features.addAll("com.Foo", "io.Bar")
+
+        when:
+        writer.generateFile()
+
+        then:
+        nativeImagePropertiesFile.text == "Args = --features=com.Foo,io.Bar\n"
+    }
+
+    def "can generate a native properties file with initialize and features"() {
+        given:
+        writer.initializeAtRuntime.addAll("com.Foo", "io.Bar")
+        writer.initializeAtBuildtime.addAll("com.FooB", "io.BarB")
+        writer.features.addAll("com.FooC", "io.BarC")
+
+        when:
+        writer.generateFile()
+
+        then:
+        nativeImagePropertiesFile.text == """Args = --initialize-at-build-time=com.FooB,io.BarB \\
+       --initialize-at-run-time=com.Foo,io.Bar \\
+       --features=com.FooC,io.BarC
+"""
+    }
+
+     def "can generate a native properties file with initialize, features and custom entries"() {
+        given:
+        writer.initializeAtRuntime.addAll("com.Foo", "io.Bar")
+        writer.initializeAtBuildtime.addAll("com.FooB", "io.BarB")
+        writer.features.addAll("com.FooC", "io.BarC")
+         writer.extraArguments.put("-H:APIFunctionPrefix", ["truffle_isolate"])
+
+        when:
+        writer.generateFile()
+
+        then:
+        nativeImagePropertiesFile.text == """Args = --initialize-at-build-time=com.FooB,io.BarB \\
+       --initialize-at-run-time=com.Foo,io.Bar \\
+       --features=com.FooC,io.BarC \\
+       -H:APIFunctionPrefix=truffle_isolate
+"""
+    }
+
+
+}


### PR DESCRIPTION
This commit introduces a new native image properties file generator. This will be useful for https://github.com/micronaut-projects/micronaut-core/issues/8073 since we want to avoid hardcoding the groupId and artifactId in `src/main/resources`. Using this task, projects which need to generate a native-image.properties file can activate generation via the `micronautBuildExtension`. For example:

```
micronautBuild {
    nativeImageProperties {
        features.add("my.AwesomeFeature")
    }
}
```