### PR TITLE
Update checkstyle to support Java17 enhanced instanceof

### DIFF
--- a/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -12,7 +12,7 @@ public abstract class MicronautBuildExtension {
 
   public static final String DEFAULT_DEPENDENCY_UPDATES_PATTERN = "(?i).+(-|\\.?)(b|M|RC|Dev)\\d?.*";
   public static final int DEFAULT_JAVA_VERSION = 17;
-  public static final String DEFAULT_CHECKSTYLE_VERSION = "8.33";
+  public static final String DEFAULT_CHECKSTYLE_VERSION = "8.41.1";
 
   private final BuildEnvironment environment;
 


### PR DESCRIPTION
I tried versions after this, but then I started seeing

```
Caused by: com.puppycrawl.tools.checkstyle.api.CheckstyleException: Property 'excludeScope' does not exist, please check the documentation
        at com.puppycrawl.tools.checkstyle.api.AutomaticBean.tryCopyProperty(AutomaticBean.java:227)
        at com.puppycrawl.tools.checkstyle.api.AutomaticBean.configure(AutomaticBean.java:194)
        at com.puppycrawl.tools.checkstyle.TreeWalker.setupChild(TreeWalker.java:123)
```

This was the latest version that supported enhanced instanceof, and still worked

See https://github.com/micronaut-projects/micronaut-session/pull/3/files#diff-7e845743b3275ae8a6a36524c32064120f1a55235372b55a5f8d2a6b685b919fR59