### PR TITLE
Skip some checks if Micronaut BOM

### DIFF
--- a/src/main/groovy/io/micronaut/build/pom/PomChecker.groovy
+++ b/src/main/groovy/io/micronaut/build/pom/PomChecker.groovy
@@ -123,7 +123,7 @@ abstract class PomChecker extends DefaultTask {
                     if (allowedGroups == null) {
                         allowedGroups = bomAuthorizedGroupIds.getOrDefault("${groupId}:${artifactId}:${version}".toString(), [] as Set)
                     }
-                    if (!groupId.startsWith(projectGroupId)) {
+                    if (!groupId.startsWith(projectGroupId) && !isMicronautBom(groupId, artifactId)) {
                         validation.pomFile.dependencies.findAll {
                             it.managed && !it.groupId.startsWith(groupId)
                         }.each {
@@ -157,6 +157,16 @@ abstract class PomChecker extends DefaultTask {
         if (failOnError.get() && errorCollector.errors) {
             throw new GradleException("BOM verification failed. See report in ${reportFile}")
         }
+    }
+
+    /**
+     * Determines if the GAV coordinates correspond to a Micronaut BOM.
+     * @param groupId the group ID
+     * @param artifactId the artifact id
+     * @return true if the GAV coordinates correspond to a Micronaut BOM
+     */
+    private static boolean isMicronautBom(String groupId, String artifactId) {
+        groupId.startsWith('io.micronaut') && artifactId.contains('bom')
     }
 
     private File writeReport(List<String> errors) {


### PR DESCRIPTION
If the current POM file being checked is a Micronaut BOM, then we assume that we don't want to check that it should only "talk" about dependencies in the same group. Otherwise, we have many validation failures because basically all of our BOMs do this.

Only BOMs which are from other sources are verified, and need an explicit suppression of error.