### PR TITLE
Add a sanity check for the resolved Micronaut version

### DIFF
--- a/src/functionalTest/groovy/io/micronaut/build/AbstractFunctionalTest.groovy
+++ b/src/functionalTest/groovy/io/micronaut/build/AbstractFunctionalTest.groovy
@@ -108,7 +108,7 @@ abstract class AbstractFunctionalTest extends Specification {
 
     private void recordOutputs() {
         output = outputWriter.toString()
-        errorOutput = errorOutput.toString()
+        errorOutput = errorOutputWriter.toString()
     }
 
     private GradleRunner newRunner(String... args) {

--- a/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
+++ b/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
@@ -41,4 +41,21 @@ You can do this directly in the project, or, better, in a convention plugin if i
        property << ["sourceCompatibility", "targetCompatibility"]
     }
 
+    void "can detect accidental upgrade of Micronaut"() {
+        given:
+        withSample("test-micronaut-module")
+
+        file("subproject1/build.gradle") << """
+            dependencies {
+                implementation("io.micronaut:micronaut-core:3.7.3")
+            }
+        """
+
+        when:
+        fails 'compileJava'
+
+        then:
+        errorOutputContains "Micronaut version mismatch: project declares 3.2.3 but resolved version is 3.7.3. You probably have a dependency which triggered an upgrade of micronaut-core. In order to determine where it comes from, you can run ./gradlew --dependencyInsight --configuration compileClasspath --dependency io.micronaut:micronaut-core"
+    }
+
 }


### PR DESCRIPTION
This commit adds a sanity check, which compares the version of Micronaut that a module declares (e.g `micronautVersion=3.4.1`) with the version which is resolved.

If the resolved version has a different major or minor, then the build will fail.