### PR TITLE
Upgrade checkstyle

### DIFF
--- a/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -12,7 +12,7 @@ public abstract class MicronautBuildExtension {
 
   public static final String DEFAULT_DEPENDENCY_UPDATES_PATTERN = "(?i).+(-|\\.?)(b|M|RC|Dev)\\d?.*";
   public static final int DEFAULT_JAVA_VERSION = 17;
-  public static final String DEFAULT_CHECKSTYLE_VERSION = "8.41.1";
+  public static final String DEFAULT_CHECKSTYLE_VERSION = "10.5.0";
 
   private final BuildEnvironment environment;
 


### PR DESCRIPTION
Upgrade to checkstyle 10.5.0 so that we properly support Java 17.

Once merged and that we release a new version of the plugin, we will have to update the project template to use new rules.
