### PR TITLE
Disable automatic download all sources and javadocs.

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -203,8 +203,8 @@ You can do this directly in the project, or, better, in a convention plugin if i
                 module {
                     outputDir file('build/classes/java/main')
                     testOutputDir file('build/classes/groovy/test')
-                    downloadJavadoc = false
-                    downloadSources = false
+                    downloadJavadoc = providers.gradleProperty("idea.download.javadoc").map(Boolean::parseBoolean).getOrElse(false)
+                    downloadSources = providers.gradleProperty("idea.download.sources").map(Boolean::parseBoolean).getOrElse(false)
                 }
             }
         }

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -203,6 +203,8 @@ You can do this directly in the project, or, better, in a convention plugin if i
                 module {
                     outputDir file('build/classes/java/main')
                     testOutputDir file('build/classes/groovy/test')
+                    downloadJavadoc = false
+                    downloadSources = false
                 }
             }
         }


### PR DESCRIPTION
This change the default behavior of the Gradle IDEA plugin, which by default download all sources for dependencies. It's enabled here in the original `IdeaModule` class:
https://github.com/gradle/gradle/blob/ed053faa4ef92bbb81d7c9bb49dd30a01080bb7c/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java#L174

IDEA allows downloading sources on demand:
![CleanShot 2022-12-03 at 21 55 47@2x](https://user-images.githubusercontent.com/139017/205444422-ae276efa-3a4f-40f8-aca0-8e7db2750bdf.png)

Disabling automatic downloading of all sources dramatically speeds up importing micronaut projects in IDEA, especially when the project updated quite a lot of dependencies, on top of that it requires less disk space. For thoose who is not frequent contributor to Micronaut projects this change is quite useful as it saves a lot of time during importing.