### PR TITLE
add missing logger paramter

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
@@ -191,7 +191,7 @@ class MicronautDocsPlugin implements Plugin<Project> {
                 versionsJson = providers.provider {
                     String ghslug = slug.get()
                     try {
-                        byte[] jsonArr = GithubApiUtils.fetchTagsFromGitHub(ghslug)
+                        byte[] jsonArr = GithubApiUtils.fetchTagsFromGitHub(logger, ghslug)
                         return new String(jsonArr, "UTF-8")
                     } catch(IOException e) {
                         logger.error("IOException fetching github tags for " + ghslug)


### PR DESCRIPTION
solves:

```
Execution failed for task ':createReleasesDropdown'.
> Error while evaluating property 'versionsJson' of task ':createReleasesDropdown'.
   > Failed to calculate the value of task ':createReleasesDropdown' property 'versionsJson'.
      > No signature of method: static io.micronaut.build.utils.GithubApiUtils.fetchTagsFromGitHub() is applicable for argument types: (String) values: [micronaut-projects/micronaut-core]
        Possible solutions: fetchTagsFromGitHub(org.gradle.api.logging.Logger, java.lang.String)

```