### PR TITLE
Populate user agent header for Github Requests

### DIFF
--- a/src/main/java/io/micronaut/build/utils/GithubApiUtils.java
+++ b/src/main/java/io/micronaut/build/utils/GithubApiUtils.java
@@ -80,6 +80,9 @@ public final class GithubApiUtils {
         URL url = new URL(githubUrl);
         HttpURLConnection con = (HttpURLConnection) url.openConnection();
         con.setRequestMethod("GET");
+        if (System.getenv("CI") != null) {
+            con.setRequestProperty("User-Agent", "Micronaut-Framework-Ci");
+        }
         con.setRequestProperty("Accept", "application/vnd.github.v3+json");
         if (System.getenv(GH_TOKEN_PUBLIC_REPOS_READONLY) != null || System.getenv(GH_USERNAME) != null) {
             con.setRequestProperty("Authorization", BasicAuthUtils.basicAuth(System.getenv(GH_USERNAME), System.getenv(GH_TOKEN_PUBLIC_REPOS_READONLY)));


### PR DESCRIPTION
https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#user-agent-required

> All API requests MUST include a valid User-Agent header. Requests with no User-Agent header will be rejected. We request that you use your GitHub username, or the name of your application, for the User-Agent header value. This allows us to contact you if there are problems.

It seems this may be the culprit why [we are still seeing a 403]( https://ge.micronaut.io/s/l2lhrfn7gzlck).

https://stackoverflow.com/questions/39907742/github-api-is-responding-with-a-403-when-using-requests-request-function

Default Github Actions Env. variables: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables