### PR TITLE
Fix race condition when verifying BOM

### DIFF
--- a/src/main/groovy/io/micronaut/build/pom/PomDownloader.java
+++ b/src/main/groovy/io/micronaut/build/pom/PomDownloader.java
@@ -15,17 +15,27 @@
  */
 package io.micronaut.build.pom;
 
+import org.gradle.api.GradleException;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class PomDownloader {
     private final List<String> repositories;
     private final File pomsDirectory;
+    private final Lock lock = new ReentrantLock();
+    private final Condition condition = lock.newCondition();
+    private final Set<String> processing = new HashSet<>();
 
     public PomDownloader(List<String> repositories, File pomDirectory) {
         this.repositories = repositories;
@@ -49,6 +59,20 @@ public class PomDownloader {
         String version = dependency.getVersion();
         String pomFilePath = "/" + group.replace('.', '/') + "/" + artifact + "/" + version + "/" + artifact + "-" + version + ".pom";
         String uri = repositoryUrl + pomFilePath;
+        lock.lock();
+        try {
+            // Multiple threads can be trying to download and copy the POM file
+            // concurrently, so we need to make them wait if another thread is
+            // already processing the same POM file.
+            while (processing.contains(pomFilePath)) {
+                condition.await();
+            }
+            processing.add(pomFilePath);
+        } catch (InterruptedException e) {
+            throw new GradleException("Unable to download POM at "+ uri, e);
+        } finally {
+            lock.unlock();
+        }
         try {
             URL url = new URL(uri);
             File pomFile = new File(pomsDirectory, pomFilePath);
@@ -61,6 +85,14 @@ public class PomDownloader {
             return Optional.of(pomFile);
         } catch (IOException e) {
             return Optional.empty();
+        } finally {
+            lock.lock();
+            try {
+                processing.remove(pomFilePath);
+                condition.signalAll();
+            } finally {
+                lock.unlock();
+            }
         }
     }
 }


### PR DESCRIPTION
When verifying that a BOM file only refers to dependencies which exist on remote repositories, we perform parallel verification of all artifacts in the dependency graph, in order to make verification faster.

However, it is possible that the same dependency appears multiple times in the graph, in which case we could try to download the same file concurrently, which is fine, but we would also try to copy the result into our local cache. This step could fail because another thread could be writing the same file.

In order to protect from this, we now make sure that concurrent requests for the same artifact are blocked.

This problem was accidentally discovered by @dstepanov .