### PR TITLE
Upgrade GE plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     }
     implementation 'org.jsoup:jsoup:1.15.3'
 
-    implementation 'com.gradle:gradle-enterprise-gradle-plugin:3.11.4'
+    implementation 'com.gradle:gradle-enterprise-gradle-plugin:3.12.3'
     implementation 'org.nosphere.gradle.github:gradle-github-actions-plugin:1.3.2'
     implementation 'com.gradle:common-custom-user-data-gradle-plugin:1.8.2'
     implementation 'org.gradle:test-retry-gradle-plugin:1.4.1'

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -106,7 +106,6 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
     private void configureJavaPlugin(Project project, MicronautBuildExtension micronautBuildExtension) {
         project.apply plugin: "groovy"
         project.apply plugin: "java-library"
-        project.pluginManager.apply('org.gradle.test-retry')
 
         def javaPluginExtension = project.extensions.findByType(JavaPluginExtension)
         javaPluginExtension.toolchain.languageVersion.convention(micronautBuildExtension.javaVersion.map(JavaLanguageVersion::of))


### PR DESCRIPTION
This will re-activate predictive test selection which is now disabled because we use an outdated version of the plugin.