### PR TITLE
Remove test retry plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,7 @@ dependencies {
     implementation 'com.gradle:gradle-enterprise-gradle-plugin:3.12.3'
     implementation 'org.nosphere.gradle.github:gradle-github-actions-plugin:1.3.2'
     implementation 'com.gradle:common-custom-user-data-gradle-plugin:1.8.2'
-    implementation 'org.gradle:test-retry-gradle-plugin:1.4.1'
-    implementation 'me.champeau.gradle:japicmp-gradle-plugin:0.4.1'
+    implementation 'me.champeaugit .gradle:japicmp-gradle-plugin:0.4.1'
 
     implementation 'org.tomlj:tomlj:1.1.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'com.gradle:gradle-enterprise-gradle-plugin:3.12.3'
     implementation 'org.nosphere.gradle.github:gradle-github-actions-plugin:1.3.2'
     implementation 'com.gradle:common-custom-user-data-gradle-plugin:1.8.2'
-    implementation 'me.champeaugit .gradle:japicmp-gradle-plugin:0.4.1'
+    implementation 'me.champeau.gradle:japicmp-gradle-plugin:0.4.1'
 
     implementation 'org.tomlj:tomlj:1.1.0'
 


### PR DESCRIPTION
This is a follow-up to #472 : the plugin is no longer required as this is bundled into the GE plugin.