### PR TITLE
Make it possible to run tests on specific JDK

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -126,10 +126,18 @@ You can do this directly in the project, or, better, in a convention plugin if i
             }
         }
 
+        def useVendorAsInput = project.providers.environmentVariable("MICRONAUT_TEST_USE_VENDOR")
+                .map(Boolean::parseBoolean).getOrElse(false)
         project.tasks.withType(Test).configureEach {
             jvmArgs '-Duser.country=US'
             jvmArgs '-Duser.language=en'
             useJUnitPlatform()
+            if (useVendorAsInput) {
+                // This will have to be changed once we switch to toolchain support, since it will not be relevant anymore
+                def vendor = project.providers.systemProperty("java.vendor").getOrElse("unknown")
+                println("Configuring test task ${it.path} to execute specifically for vendor: $vendor")
+                inputs.property("java.vendor", vendor)
+            }
             retry {
                 if (micronautBuildExtension.environment.isGithubAction().getOrElse(false)) {
                     maxRetries.set(2)


### PR DESCRIPTION
This commit adds the ability to run tests on a specific JDK, by making the `java.vendor` an input to the test tasks. In order to reduce the impact on caching for other users, this is opt-in: it will require setting the `MICRONAUT_TEST_USE_VENDOR` environment variable to `true` in a workflow, in which case the tests will have the vendor as an additional input.

Important: this will only work for modules which apply the `io.micronaut.build.internal.common` plugin (which is the case for `io.micronaut.build.internal.base-module` and `io.micronaut.build.internal.module`), so it is likely that projects which also include test suites or benchmarks will have to do something similar if they want tests to be executed on a different JDK.

Fixes #494