### PR TITLE
Add java details as tags to the build scan

### DIFF
--- a/src/main/java/io/micronaut/build/MicronautGradleEnterprisePlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautGradleEnterprisePlugin.java
@@ -20,6 +20,7 @@ import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
 import com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin;
 import com.gradle.enterprise.gradleplugin.testdistribution.TestDistributionPlugin;
 import com.gradle.scan.plugin.BuildScanExtension;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.invocation.Gradle;
@@ -62,6 +63,7 @@ public class MicronautGradleEnterprisePlugin implements Plugin<Settings> {
         boolean isCI = ProviderUtils.guessCI(providers);
         configureBuildScansPublishing(ge, isCI, publishScanOnDemand);
         settings.getGradle().projectsLoaded(MicronautGradleEnterprisePlugin::applyGitHubActionsPlugin);
+        tagWithJavaDetails(ge, providers);
         if (providers.gradleProperty("org.gradle.caching").map(Boolean::parseBoolean).orElse(true).get()) {
             settings.getGradle().settingsEvaluated(lateSettings -> {
                 BuildCacheConfiguration buildCache = settings.getBuildCache();
@@ -100,6 +102,14 @@ public class MicronautGradleEnterprisePlugin implements Plugin<Settings> {
             }
             captureSafeEnvironmentVariables(ge);
         }
+    }
+
+    private void tagWithJavaDetails(GradleEnterpriseExtension ge, ProviderFactory providers) {
+        Provider<String> vendor = providers.systemProperty("java.vendor");
+        if (vendor.isPresent()) {
+            ge.getBuildScan().tag("vendor:" + vendor.get().toLowerCase().replaceAll("\\W+", "_"));
+        }
+        ge.getBuildScan().tag("jdk:" + JavaVersion.current().getMajorVersion());
     }
 
     private void captureSafeEnvironmentVariables(GradleEnterpriseExtension ge) {


### PR DESCRIPTION
When investigating flakiness, it's useful to see (at a glance) whether there's some commonality to the flaky builds.

This PR adds two tags to build scans.

The current jdk vendor taken from the system properties, and the current major Java version running the build.

The vendor is munged so non alphanumeric chars are replaced by underscores, ie: 'Azul Systems, Inc.' becomes 'Azul_Systems_Inc_'