### PR TITLE
Fix AOT test fixtures coordinates

### DIFF
--- a/src/main/groovy/io/micronaut/build/aot/MicronautAotModulePlugin.java
+++ b/src/main/groovy/io/micronaut/build/aot/MicronautAotModulePlugin.java
@@ -48,13 +48,19 @@ public class MicronautAotModulePlugin implements Plugin<Project> {
         deps.addProvider(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, aotExtension.getVersion().map(version -> {
             String aot = aotModule("core", version);
             ExternalModuleDependency dependency = (ExternalModuleDependency) deps.create(aot);
-            dependency.capabilities(capabilities -> capabilities.requireCapability("io.micronaut.aot:aot-core-test-fixtures"));
+            dependency.capabilities(capabilities -> capabilities.requireCapability(aotTestFixtures("core", version)));
             return dependency;
         }));
     }
 
     private static String aotModule(String name, String version) {
         return "io.micronaut.aot:micronaut-aot-" + name + ":" + version;
+    }
+
+    private static String aotTestFixtures(String name, String version) {
+        int major = Integer.parseInt(version.split("\\.")[0]);
+        String prefix = major < 2 ? "" : "micronaut-";
+        return "io.micronaut.aot:" + prefix + "aot-" + name + "-test-fixtures:" + version;
     }
 
     private static String coreModule(String name, String version) {


### PR DESCRIPTION
Micronaut AOT 2.0.0 uses different capability coordinates for its test fixtures (consistenly with the main GAV coordinates). This commit adds support for the new capability.

@sdelamo this fixes the issue you've reported in https://github.com/micronaut-projects/micronaut-security/pull/1250#discussion_r1135003805