### PR TITLE
Prefer project modules in conflict resolution

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautDependencyResolutionConfigurationPlugin.java
+++ b/src/main/groovy/io/micronaut/build/MicronautDependencyResolutionConfigurationPlugin.java
@@ -1,6 +1,7 @@
 package io.micronaut.build;
 
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.initialization.resolve.RepositoriesMode;
@@ -14,7 +15,12 @@ public class MicronautDependencyResolutionConfigurationPlugin implements Microna
     public void apply(Project project) {
         addMavenCentral(project);
         configureDependencySubstitutions(project);
+        configureResolutionStrategy(project);
         configureDependencyCaching(project);
+    }
+
+    private static void configureResolutionStrategy(Project project) {
+        project.getConfigurations().all(conf -> conf.resolutionStrategy(ResolutionStrategy::preferProjectModules));
     }
 
     private static void configureDependencyCaching(Project project) {
@@ -41,7 +47,7 @@ public class MicronautDependencyResolutionConfigurationPlugin implements Microna
 
     }
 
-    public void configureDependencySubstitutions(Project project) {
+    public static void configureDependencySubstitutions(Project project) {
         project.getGradle().settingsEvaluated(settings -> {
             MicronautBuildSettingsExtension buildSettingsExtension = settings.getExtensions().getByType(MicronautBuildSettingsExtension.class);
             project.getGradle().projectsEvaluated(unused -> project.getConfigurations().all(conf -> conf.getResolutionStrategy().dependencySubstitution(ds ->


### PR DESCRIPTION
We have seen releases failing when generating the javadocs. The reason is that there's conflict resolution happening between versions like `-M1` and `-SNAPSHOT`, where `-SNAPSHOT` wins. The consequence is that when we compute the javadoc classpath, we don't resolve project dependencies, but binaries, which miss the javadoc classpath variant.

In general, we should always prefer the project mdoules during conflict resolution: it is extremely unlikely we intentionally want to use a binary version of a project instead of the local version. Should this happen, the project can override the configuration by calling:

```
configurations.all {
   resolutionStrategy {
      failOnVersionConflict()
   }
}
```
then explicitly handle conflict resolution. This
is arguably a bit painful, but there's no method
on `ResolutionStrategy` to revert to the default
behavior.