### PR TITLE
Fix registration of checkPom task

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
@@ -25,8 +25,10 @@ class MicronautBaseModulePlugin implements Plugin<Project> {
         project.pluginManager.apply(MicronautBinaryCompatibilityPlugin)
         configureJUnit(project)
         assertSettingsPluginApplied(project)
-        PomCheckerUtils.registerPomChecker("checkPom", project, project.extensions.findByType(PublishingExtension)) {
-            it.suppressions.convention(project.extensions.getByType(MicronautBuildExtension).bomSuppressions)
+        project.pluginManager.withPlugin("maven-publish") {
+            PomCheckerUtils.registerPomChecker("checkPom", project, project.extensions.findByType(PublishingExtension)) {
+                it.suppressions.convention(project.extensions.getByType(MicronautBuildExtension).bomSuppressions)
+            }
         }
     }
 


### PR DESCRIPTION
The issue was discovered while working on converting a Maven build to a Micronaut Gradle build. One of the submodules had `doc` in its name, which caused it to skip publication, because our publishing plugin ignores all projects which name contains `doc`. When this happens, the `maven-publish` plugin wasn't applied, which caused a NPE:

https://ge.micronaut.io/s/nhcjp4oily63w

Even if the `maven-publish` plugin was explicitly added, then the registration would fail because the publication that we expect in checkPom is missing:

https://ge.micronaut.io/s/css5vunwizpsc

This commit fixes the bug by making sure that we only register the `checkPom` task if the maven publish plugin is applied.