### PR TITLE
Remove the Groovydoc plugin use

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     implementation libs.commons.lang3
     implementation libs.snakeyaml
     implementation libs.grails.gdoc
-    implementation libs.groovydoc.plugin
     implementation libs.asciidoctorj
     implementation libs.spotless.plugin
     implementation libs.testlogger.plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ gradle-custom-userdata-plugin = "1.10"
 gradle-enterprise-plugin = "3.12.6"
 gradle-github-actions-plugin = "1.3.2"
 grails-gdoc = "1.0.1"
-groovydoc-plugin = "1.0.1"
 mockserver = "5.15.0"
 nexus-publish-plugin = "1.2.0"
 snakeyaml = "1.33"
@@ -25,7 +24,6 @@ gradle-custom-userdata-plugin = { module = "com.gradle:common-custom-user-data-g
 gradle-enterprise-plugin = { module = "com.gradle:gradle-enterprise-gradle-plugin", version.ref = "gradle-enterprise-plugin" }
 gradle-github-actions-plugin = { module = "org.nosphere.gradle.github:gradle-github-actions-plugin", version.ref = "gradle-github-actions-plugin" }
 grails-gdoc = { module = "org.grails:grails-gdoc-engine", version.ref = "grails-gdoc" }
-groovydoc-plugin = { module = "io.github.groovylang.groovydoc:io.github.groovylang.groovydoc.gradle.plugin", version.ref = "groovydoc-plugin" }
 nexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexus-publish-plugin" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }
 mockserver-client = { module = "org.mock-server:mockserver-client-java", version.ref = "mockserver" }

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -13,7 +13,7 @@ import org.gradle.api.tasks.diagnostics.DependencyReportTask
 import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.tasks.Jar
 import org.gradle.jvm.toolchain.JavaLanguageVersion
-import org.groovy.lang.groovydoc.tasks.GroovydocTask
+import org.gradle.api.tasks.javadoc.Groovydoc
 
 import static io.micronaut.build.BomSupport.coreBomArtifactId
 import static io.micronaut.build.utils.VersionHandling.versionProviderOrDefault
@@ -97,7 +97,7 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
             })
         }
 
-        project.tasks.withType(GroovydocTask).configureEach {
+        project.tasks.withType(Groovydoc).configureEach {
             classpath += project.configurations.documentation
         }
     }


### PR DESCRIPTION
This plugin causes a resolution error failure when releasing. We switch to Gradle's groovydoc task instead, which shouldn't be a problem because we have almost no Groovy classes in the public API and it seems that Groovy docs are not published as part of the documentation we build in `docs`.

I will perform a new 6.3.x and 6.4.x release once this is merged, to unblock releases.