### PR TITLE
Conditionally configure Gradle Enterprise

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -18,6 +18,7 @@ import org.gradle.api.tasks.javadoc.Groovydoc
 
 import static io.micronaut.build.BomSupport.coreBomArtifactId
 import static io.micronaut.build.utils.VersionHandling.versionProviderOrDefault
+
 /**
  * Micronaut internal Gradle plugin. Not intended to be used in user's projects.
  */
@@ -76,15 +77,15 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
             project.configurations.testAnnotationProcessor.dependencies.addAllLater(injectGroovyIfProcessingEnabled)
 
             dependencies.addProvider("documentation", groovyGroupProvider.zip(groovyVersionProvider) { groovyGroup, groovyVersion ->
-               "$groovyGroup:groovy-templates:$groovyVersion"
+                "$groovyGroup:groovy-templates:$groovyVersion"
             })
             dependencies.addProvider("documentation", groovyGroupProvider.zip(groovyVersionProvider) { groovyGroup, groovyVersion ->
-               "$groovyGroup:groovy-dateutil:$groovyVersion"
+                "$groovyGroup:groovy-dateutil:$groovyVersion"
             })
             dependencies.addProvider("testCompileOnly", micronautVersionProvider.map { micronautVersion ->
                 "io.micronaut:micronaut-inject-groovy:${micronautVersion}"
             })
-            dependencies.addProvider("testImplementation",groovyGroupProvider.zip(groovyVersionProvider) { groovyGroup, groovyVersion ->
+            dependencies.addProvider("testImplementation", groovyGroupProvider.zip(groovyVersionProvider) { groovyGroup, groovyVersion ->
                 "$groovyGroup:groovy-test:$groovyVersion"
             })
             dependencies.addProvider("testImplementation", byteBuddyVersionProvider.map {
@@ -148,6 +149,9 @@ You can do this directly in the project, or, better, in a convention plugin if i
             }
             predictiveSelection {
                 enabled = micronautBuildExtension.environment.isTestSelectionEnabled()
+            }
+            distribution {
+                enabled = false
             }
         }
 

--- a/src/main/java/io/micronaut/build/BuildEnvironment.java
+++ b/src/main/java/io/micronaut/build/BuildEnvironment.java
@@ -52,15 +52,19 @@ public class BuildEnvironment {
         // an environment variable is explicitly configured and set to true
         // or a system property is explicitly configured and set to true
         // or it's a local build
-        return providers.environmentVariable(PREDICTIVE_TEST_SELECTION_ENV_VAR)
-                .orElse(providers.systemProperty(PREDICTIVE_TEST_SELECTION_SYSPROP))
-                .map(it -> {
-                    if (it.trim().length() > 0) {
-                        return Boolean.parseBoolean(it);
-                    }
-                    return false;
-                })
-                .orElse(isNotGithubAction());
+        Provider<String> projectGroup = providers.gradleProperty("projectGroup");
+        if (projectGroup.isPresent() && projectGroup.get().startsWith("io.micronaut")) {
+            return providers.environmentVariable(PREDICTIVE_TEST_SELECTION_ENV_VAR)
+                    .orElse(providers.systemProperty(PREDICTIVE_TEST_SELECTION_SYSPROP))
+                    .map(it -> {
+                        if (it.trim().length() > 0) {
+                            return Boolean.parseBoolean(it);
+                        }
+                        return false;
+                    })
+                    .orElse(isNotGithubAction());
+        }
+        return providers.provider(() -> false);
     }
 
     public void duringMigration(Runnable action) {

--- a/src/main/java/io/micronaut/build/MicronautGradleEnterprisePlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautGradleEnterprisePlugin.java
@@ -47,6 +47,12 @@ public class MicronautGradleEnterprisePlugin implements Plugin<Settings> {
         pluginManager.apply(MicronautBuildSettingsPlugin.class);
         pluginManager.apply(GradleEnterprisePlugin.class);
         pluginManager.apply(CommonCustomUserDataGradlePlugin.class);
+        Provider<String> projectGroup = settings.getProviders().gradleProperty("projectGroup");
+        if (projectGroup.isPresent() && !projectGroup.get().startsWith("io.micronaut")) {
+            // Do not apply the Gradle Enterprise plugin if the project doesn't belong to
+            // our own group
+            return;
+        }
         GradleEnterpriseExtension ge = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
         MicronautBuildSettingsExtension micronautBuildSettingsExtension = settings.getExtensions().getByType(MicronautBuildSettingsExtension.class);
         configureGradleEnterprise(settings, ge, micronautBuildSettingsExtension);

--- a/src/test/groovy/io/micronaut/build/docs/CreateReleasesDropdownTaskSpec.groovy
+++ b/src/test/groovy/io/micronaut/build/docs/CreateReleasesDropdownTaskSpec.groovy
@@ -16,21 +16,45 @@ class CreateReleasesDropdownTaskSpec extends Specification {
 
     }
     void "options are correctly populated"() {
-        given:
-        String slug = "micronaut-projects/micronaut-liquibase"
+        String json = """[
+  {
+    "name": "v5.7.2",
+    "zipball_url": "https://api.github.com/repos/micronaut-projects/micronaut-liquibase/zipball/refs/tags/v5.7.2",
+    "tarball_url": "https://api.github.com/repos/micronaut-projects/micronaut-liquibase/tarball/refs/tags/v5.7.2",
+    "commit": {
+      "sha": "7095bcf7f0fed09411da2573c653836cba212962",
+      "url": "https://api.github.com/repos/micronaut-projects/micronaut-liquibase/commits/7095bcf7f0fed09411da2573c653836cba212962"
+    },
+    "node_id": "MDM6UmVmMTU4MjExNzk4OnJlZnMvdGFncy92NS43LjI="
+  },
+  {
+    "name": "v5.7.1",
+    "zipball_url": "https://api.github.com/repos/micronaut-projects/micronaut-liquibase/zipball/refs/tags/v5.7.1",
+    "tarball_url": "https://api.github.com/repos/micronaut-projects/micronaut-liquibase/tarball/refs/tags/v5.7.1",
+    "commit": {
+      "sha": "ad226fa161d14929f5ae36b25c338d2f3072e3e0",
+      "url": "https://api.github.com/repos/micronaut-projects/micronaut-liquibase/commits/ad226fa161d14929f5ae36b25c338d2f3072e3e0"
+    },
+    "node_id": "MDM6UmVmMTU4MjExNzk4OnJlZnMvdGFncy92NS43LjE="
+  },
+  {
+    "name": "v5.7.0",
+    "zipball_url": "https://api.github.com/repos/micronaut-projects/micronaut-liquibase/zipball/refs/tags/v5.7.0",
+    "tarball_url": "https://api.github.com/repos/micronaut-projects/micronaut-liquibase/tarball/refs/tags/v5.7.0",
+    "commit": {
+      "sha": "36341fa043716360a9cf044e9f902e0c399cd8f8",
+      "url": "https://api.github.com/repos/micronaut-projects/micronaut-liquibase/commits/36341fa043716360a9cf044e9f902e0c399cd8f8"
+    },
+    "node_id": "MDM6UmVmMTU4MjExNzk4OnJlZnMvdGFncy92NS43LjA="
+  }
+]
+"""
 
         when:
-        String url = "https://api.github.com/repos/${slug}/tags"
-        String json = new URL(url).text
+        String html = CreateReleasesDropdownTask.composeSelectHtml(json, "micronaut-projects/micronaut-liquibase", "5.7.0")
 
         then:
         noExceptionThrown()
-
-        when:
-        String html = CreateReleasesDropdownTask.composeSelectHtml(json, "micronaut-projects/micronaut-liquibase", "5.6.0")
-
-        then:
-        noExceptionThrown()
-        html.contains("<option value='https://micronaut-projects.github.io/micronaut-liquibase/5.5.0/guide/index.html'>5.5.0</option>")
+        html.contains("<option value='https://micronaut-projects.github.io/micronaut-liquibase/5.7.1/guide/index.html'>5.7.1</option>")
     }
 }


### PR DESCRIPTION
This commit removes the GE configuration when the project group is not starting with `io.micronaut`, in which case we assume it's not an OSS project that we maintain, and therefore the GE configuration makes no sense.