### PR TITLE
Fix incorrect warning with Kotlin DSL

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
@@ -39,6 +39,9 @@ class MicronautBaseModulePlugin implements Plugin<Project> {
     }
 
     static void assertSettingsPluginApplied(Project project) {
+        if (project.name == "gradle-kotlin-dsl-accessors") {
+            return
+        }
         project.gradle.sharedServices.registerIfAbsent(InternalStateCheckingService.NAME, InternalStateCheckingService) { BuildServiceSpec<InternalStateCheckingService.Params> spec ->
             spec.parameters.registeredByProjectPlugin.set(true)
         }.get()


### PR DESCRIPTION
If the base module plugin is applied via a convention plugin written in Kotlin, then the settings plugin warning message is triggerred during Kotlin accessors compilation, which is wrong. This commit fixes this by hardcoding the fact that we have the project name matching accessors compilation.