### PR TITLE
Do not add version aliases to known aliases

### DIFF
--- a/src/main/groovy/io/micronaut/build/pom/VersionCatalogConverter.groovy
+++ b/src/main/groovy/io/micronaut/build/pom/VersionCatalogConverter.groovy
@@ -68,7 +68,6 @@ class VersionCatalogConverter {
             model.versionsTable.each { version ->
                 if (version.reference.startsWith('managed-')) {
                     def alias = version.reference.substring(8)
-                    knownAliases.add(alias)
                     builder.version(alias, version.version.require)
                 }
             }


### PR DESCRIPTION
It is possible that a version alias is defined, but that its library isn't (e.g when importing BOMs). This causes some modules to be missing from the generated platform catalog.

Fixes https://github.com/micronaut-projects/micronaut-platform/issues/283