### PR TITLE
Restore objenesis/bytebuddy versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import io.micronaut.internal.VersionsWriterTask
+
 plugins {
     id 'groovy-gradle-plugin'
     id 'groovy'
@@ -100,6 +102,14 @@ tasks.named('jar', Jar) {
     from docFilesJar
 }
 
+def generateVersions = tasks.register("generateVersions", VersionsWriterTask) {
+    versions.put("bytebuddy", libs.versions.bytebuddy)
+    versions.put("objenesis", libs.versions.objenesis)
+    className = "io.micronaut.build.utils.DefaultVersions"
+    outputDirectory = layout.buildDirectory.dir("generated/versions")
+}
+
+sourceSets.main.java.srcDir(generateVersions)
 
 gradlePlugin {
     // Define the plugins

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id("java-gradle-plugin")
+}

--- a/buildSrc/src/main/java/io/micronaut/internal/VersionsWriterTask.java
+++ b/buildSrc/src/main/java/io/micronaut/internal/VersionsWriterTask.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.internal;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.util.Locale;
+import java.util.Map;
+
+
+public abstract class VersionsWriterTask extends DefaultTask {
+    @Input
+    public abstract MapProperty<String, String> getVersions();
+
+    @Input
+    public abstract Property<String> getClassName();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDirectory();
+
+    @TaskAction
+    public void generate() throws IOException {
+        var className = getClassName().get();
+        var versions = getVersions().get();
+        var outputDir = getOutputDirectory().get().getAsFile();
+        var packageName = className.substring(0, className.lastIndexOf("."));
+        var simpleClassName = className.substring(className.lastIndexOf(".") + 1);
+        var parentDir = outputDir.toPath().resolve(packageName.replace('.', '/'));
+        Files.createDirectories(parentDir);
+        try (PrintWriter prn = new PrintWriter(new FileWriter(parentDir.resolve(simpleClassName + ".java").toFile()))) {
+            prn.println("package " + packageName + ";");
+            prn.println();
+            prn.println("public class " + simpleClassName + " {");
+            for (Map.Entry<String, String> entry : versions.entrySet()) {
+                var key = entry.getKey();
+                key = (key + "_VERSION").toUpperCase(Locale.US);
+                prn.println("    public final static String " + key + " = \"" + entry.getValue() + "\";");
+            }
+            prn.println("}");
+        }
+
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,12 @@ spotless-plugin = "6.12.0"
 testlogger-plugin = "3.2.0"
 tomlj = "1.1.0"
 typesafe-config = "1.4.2"
+bytebuddy = "1.14.4"
+objenesis = "3.3"
 
 [libraries]
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
+bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 japicmp-plugin = { module = "me.champeau.gradle:japicmp-gradle-plugin", version.ref = "japicmp-plugin" }
 gradle-custom-userdata-plugin = { module = "com.gradle:common-custom-user-data-gradle-plugin", version.ref = "gradle-custom-userdata-plugin" }
@@ -31,7 +34,8 @@ snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
 sonar-plugin = { module = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin", version.ref = "sonar-plugin" }
 spock-bom = { module = "org.spockframework:spock-bom", version.ref = "spock" }
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
-spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless-plugin"}
-testlogger-plugin = { module = "com.adarshr:gradle-test-logger-plugin", version.ref = "testlogger-plugin"}
+spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless-plugin" }
+testlogger-plugin = { module = "com.adarshr:gradle-test-logger-plugin", version.ref = "testlogger-plugin" }
 tomlj = { module = "org.tomlj:tomlj", version.ref = "tomlj" }
 typesafe-config = { module = "com.typesafe:config", version.ref = "typesafe-config" }
+objenesis = { module = "org.objenesis:objenesis", version.ref = "objenesis" }

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.build
 
 import com.diffplug.gradle.spotless.SpotlessTask
+import io.micronaut.build.utils.DefaultVersions
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -43,8 +44,8 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
                     'org.codehaus.groovy' :
                     'org.apache.groovy'
         }
-        def byteBuddyVersionProvider = versionProviderOrDefault(project, 'bytebuddy', List.of("libs", "mnTest"), '')
-        def objenesisVersionProvider = versionProviderOrDefault(project, 'objenesis', List.of("libs", "mnTest"),'')
+        def byteBuddyVersionProvider = versionProviderOrDefault(project, 'bytebuddy', List.of("libs", "mnTest"), DefaultVersions.BYTEBUDDY_VERSION)
+        def objenesisVersionProvider = versionProviderOrDefault(project, 'objenesis', List.of("libs", "mnTest"), DefaultVersions.OBJENESIS_VERSION)
         def logbackVersionProvider = versionProviderOrDefault(project, 'logback', List.of("libs", "mnLogging"), '')
 
         project.configurations {


### PR DESCRIPTION
Turns out these are needed for mocking. But instead of hardcoding the version in sources, they are now externalized in the catalog, which should give us the benefit of automated upgrades.