### PR TITLE
Relativize repoUrl to allow cache relocatability on PomChecker task

### DIFF
--- a/src/main/groovy/io/micronaut/build/pom/PomCheckerUtils.java
+++ b/src/main/groovy/io/micronaut/build/pom/PomCheckerUtils.java
@@ -46,6 +46,10 @@ public abstract class PomCheckerUtils {
             ArtifactRepository repo = publishing.getRepositories().findByName("Build");
             if (repo instanceof MavenArtifactRepository) {
                 repoUrl = ((MavenArtifactRepository) repo).getUrl().toString();
+                try {
+                    // try to relativize to allow cache relocatability
+                    repoUrl = project.relativePath(repoUrl);
+                } catch(IllegalArgumentException ignored) {}
             }
             task.getRepositories().add(repoUrl);
             project.getRepositories().forEach(r -> {


### PR DESCRIPTION
## Issue
the `checkPom` task is suffering a cache miss when its cache is relocated.
This is due to changes on the `repositories` property.

<img width="707" alt="Screenshot 2023-06-02 at 4 02 35 PM" src="https://github.com/micronaut-projects/micronaut-build/assets/10243934/be435a42-62b7-4ad2-9f83-e882e9572f0d">

## Cause
The issue is that the `MicronautPublishingPlugin` is [adding a repository](https://github.com/micronaut-projects/micronaut-build/blob/6460d503f3f962b624de0c086020c8f483846dff/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.java#L132) which is added to the repository input [as an absolute path](https://github.com/micronaut-projects/micronaut-build/blob/6460d503f3f962b624de0c086020c8f483846dff/src/main/groovy/io/micronaut/build/pom/PomCheckerUtils.java#L53).

## Fix
Relativizing the path when adding it to the input.