### PR TITLE
Fix dependency on `findbaseLine` when baseline is defined

### DIFF
--- a/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
+++ b/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
@@ -114,7 +114,11 @@ public class MicronautBinaryCompatibilityPlugin implements Plugin<Project> {
                 baselineConfig.getDependencies().addLater(baseline.map(version -> project.getDependencies().create(project.getGroup() + ":" + moduleNameOf(project.getName()) + ":" + version + "@toml")));
                 TaskProvider<VersionCatalogCompatibilityCheck> compatibilityCheckTaskProvider = tasks.register("checkVersionCatalogCompatibility", VersionCatalogCompatibilityCheck.class, task -> {
                     task.onlyIf(t -> binaryCompatibility.getEnabled().getOrElse(true));
-                    task.getBaseline().fileProvider(baselineTask.map(b -> baselineConfig.getSingleFile()));
+                    if (binaryCompatibility.getBaselineVersion().isPresent()) {
+                        task.getBaseline().fileProvider(providers.provider(baselineConfig::getSingleFile));
+                    } else {
+                        task.getBaseline().fileProvider(baselineTask.map(b -> baselineConfig.getSingleFile()));
+                    }
                     task.getCurrent().convention(tasks.named("generateCatalogAsToml", TomlFileGenerator.class).flatMap(TomlFileGenerator::getOutputFile));
                     task.getReportFile().convention(project.getLayout().getBuildDirectory().file("reports/version-catalog-compatibility.txt"));
                     MicronautBomExtension bomExtension = project.getExtensions().findByType(MicronautBomExtension.class);


### PR DESCRIPTION
If the baseline is explicitely set in the extension, the BOM version catalog compatibility check was still introducing a dependency on the findBaseline task which is doomed to fail.

Fixes #584