### PR TITLE
Workaround for ClassCastException

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -173,8 +173,8 @@ You can do this directly in the project, or, better, in a convention plugin if i
                 options.encoding = "UTF-8"
                 options.compilerArgs.add('-parameters')
                 if (micronautBuildExtension.enableProcessing.get()) {
-                    options.compilerArgs.add("-Amicronaut.processing.group=$project.group")
-                    options.compilerArgs.add("-Amicronaut.processing.module=micronaut-$project.name")
+                    options.compilerArgs.add("-Amicronaut.processing.group=$project.group".toString())
+                    options.compilerArgs.add("-Amicronaut.processing.module=micronaut-$project.name".toString())
                 }
                 compileOptions.applyTo(options)
             }


### PR DESCRIPTION
The Sonar plugin (rightfully) assumes that options added to the compiler are instances of `String` because typed as a `List<String>`. Whenever compilerArgs.stream() is called, a class cast exception happens. However, build scripts often add arguments as GString in Groovy scripts.

To workaround this, we configure the compiler options by coercing to a `String` in an `afterEvaluate`.