### PR TITLE
Fix BOMs not being inlined

### DIFF
--- a/src/functionalTest/gradle-projects/test-bom-module/gradle/libs.versions.toml
+++ b/src/functionalTest/gradle-projects/test-bom-module/gradle/libs.versions.toml
@@ -2,10 +2,12 @@
 asm = "9.5"
 
 managed-dekorate = "3.7.0"
+managed-junit = "5.9.10"
 managed-micronaut-aws = "4.0.1"
 
 [libraries]
 boms-micronaut-aws = { module = "io.micronaut.aws:micronaut-aws-bom", version.ref = "managed-micronaut-aws" }
+boms-junit = { module = "org.junit:junit-bom", version.ref = "managed-junit"}
 
 #
 # Libraries which start with managed- are managed by Micronaut in the sense

--- a/src/functionalTest/groovy/io/micronaut/build/catalogs/BomGenerationFunctionalTest.groovy
+++ b/src/functionalTest/groovy/io/micronaut/build/catalogs/BomGenerationFunctionalTest.groovy
@@ -30,6 +30,7 @@ aws-lambda = "1.2.2"
 aws-lambda-events = "3.11.2"
 aws-lambda-java-serialization = "1.1.2"
 dekorate = "3.7.0"
+junit = "5.9.10"
 micronaut-aws = "4.0.1"
 micronaut-test-bom-module = "1.2.3"
 
@@ -42,6 +43,7 @@ aws-lambda-core = {group = "com.amazonaws", name = "aws-lambda-java-core", versi
 aws-lambda-events = {group = "com.amazonaws", name = "aws-lambda-java-events", version.ref = "aws-lambda-events" }
 aws-lambda-java-serialization = {group = "com.amazonaws", name = "aws-lambda-java-serialization", version.ref = "aws-lambda-java-serialization" }
 awssdk-secretsmanager = {group = "software.amazon.awssdk", name = "secretsmanager", version.ref = "aws-java-sdk-v2" }
+boms-junit = {group = "org.junit", name = "junit-bom", version.ref = "junit" }
 dekorate = {group = "io.dekorate", name = "dekorate-project", version.ref = "dekorate" }
 micronaut-aws-alexa = {group = "io.micronaut.aws", name = "micronaut-aws-alexa", version.ref = "micronaut-aws" }
 micronaut-aws-alexa-httpserver = {group = "io.micronaut.aws", name = "micronaut-aws-alexa-httpserver", version.ref = "micronaut-aws" }
@@ -98,6 +100,7 @@ aws-lambda = "1.2.2"
 aws-lambda-events = "3.11.2"
 aws-lambda-java-serialization = "1.1.2"
 dekorate = "3.7.0"
+junit = "5.9.10"
 micronaut-aws = "4.0.1"
 micronaut-test-bom-module = "1.2.3"
 
@@ -110,6 +113,7 @@ aws-lambda-core = {group = "com.amazonaws", name = "aws-lambda-java-core", versi
 aws-lambda-events = {group = "com.amazonaws", name = "aws-lambda-java-events", version.ref = "aws-lambda-events" }
 aws-lambda-java-serialization = {group = "com.amazonaws", name = "aws-lambda-java-serialization", version.ref = "aws-lambda-java-serialization" }
 awssdk-secretsmanager = {group = "software.amazon.awssdk", name = "secretsmanager", version.ref = "aws-java-sdk-v2" }
+boms-junit = {group = "org.junit", name = "junit-bom", version.ref = "junit" }
 dekorate = {group = "io.dekorate", name = "dekorate-project", version.ref = "dekorate" }
 micronaut-aws-alexa = {group = "io.micronaut.aws", name = "micronaut-aws-alexa", version.ref = "micronaut-aws" }
 micronaut-aws-alexa-httpserver = {group = "io.micronaut.aws", name = "micronaut-aws-alexa-httpserver", version.ref = "micronaut-aws" }


### PR DESCRIPTION
This commit fixes a problem where some aliases were not inlined in the platform BOM. For example, the `junit` BOM dependency is missing from the platform, despite `micronaut-test` including it.

The reason is that in `micronaut-test`, `junit` is a managed version, but for a BOM (alias `boms-...`). There were 2 ways to fix this problem:

1. include all versions from the embedded catalog during inlining. This worked, but with a drawback: only the version would be included (e.g `junit`), but no library would be present. Which means that the user would still have to figure out the coordinates of, say, the junit BOM.
2. the fix in this PR, which is to include `boms-` dependencies into the generated catalog. This works well and should be backwards compatible, since we're only adding new entries to the catalogs.

It's worth noting that we _don't_ do this for `boms-micronaut-` entries, which, in this case, are available as independent version catalogs. Including them would lead to potentially many BOM inclusion conflicts, since many projects may include other Micronaut BOMs.

Fixes #611