### PR TITLE
Fix JDK macro

### DIFF
--- a/src/main/groovy/io/micronaut/docs/ApiMacro.groovy
+++ b/src/main/groovy/io/micronaut/docs/ApiMacro.groovy
@@ -83,7 +83,13 @@ class ApiMacro extends InlineMacroProcessor {
         } catch (e) {
             baseUri = getBaseUri(Collections.emptyMap(), getAttributeKey(), lib)
         }
-
+        String module = target.startsWith("java") ? "java.base" : null
+        if (attributes.module) {
+            module = attributes.module
+        }
+        if (module) {
+            baseUri = "${baseUri}/${module}"
+        }
 
         if (attributes.text) {
             shortName = attributes.text

--- a/src/main/groovy/io/micronaut/docs/Jdk.groovy
+++ b/src/main/groovy/io/micronaut/docs/Jdk.groovy
@@ -4,7 +4,7 @@ import groovy.transform.CompileStatic
 
 @CompileStatic
 class Jdk implements JvmLibrary {
-    private static final String DEFAULT_URI = "https://docs.oracle.com/javase/17/docs/api"
+    private static final String DEFAULT_URI = "https://docs.oracle.com/en/java/javase/17/docs/api"
 
     @Override
     String defaultUri() {

--- a/src/test/groovy/io/micronaut/docs/AbstractConverterSpec.groovy
+++ b/src/test/groovy/io/micronaut/docs/AbstractConverterSpec.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.docs
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.Attributes
+import org.asciidoctor.Options
+import org.asciidoctor.SafeMode
+import spock.lang.Specification
+
+class AbstractConverterSpec extends Specification {
+    private Asciidoctor asciidoctor
+    protected Options options
+    protected String converted
+
+    def setup() {
+        asciidoctor = Asciidoctor.Factory.create()
+        asciidoctor.javaExtensionRegistry().block(new ConfigurationPropertiesMacro(asciidoctor))
+        options = Options.builder()
+                .safe(SafeMode.SAFE)
+                .attributes(
+                        Attributes.builder()
+                                .attribute('source-highlighter', 'highlightjs')
+                                .build()
+                )
+                .backend("html5")
+                .build()
+    }
+
+    def cleanup() {
+        asciidoctor.shutdown()
+    }
+
+
+    void convert(String input) {
+        converted = asciidoctor.convert(input, options)
+    }
+}

--- a/src/test/groovy/io/micronaut/docs/ConfigurationPropertiesMacroSpec.groovy
+++ b/src/test/groovy/io/micronaut/docs/ConfigurationPropertiesMacroSpec.groovy
@@ -1,33 +1,6 @@
 package io.micronaut.docs
 
-import org.asciidoctor.Asciidoctor
-import org.asciidoctor.Attributes
-import org.asciidoctor.Options
-import org.asciidoctor.SafeMode
-import spock.lang.Specification
-
-class ConfigurationPropertiesMacroSpec extends Specification {
-    private Asciidoctor asciidoctor
-    private String converted
-    private Options options
-
-    def setup() {
-        asciidoctor = Asciidoctor.Factory.create()
-        asciidoctor.javaExtensionRegistry().block(new ConfigurationPropertiesMacro(asciidoctor))
-        options = Options.builder()
-                .safe(SafeMode.SAFE)
-                .attributes(
-                        Attributes.builder()
-                                .attribute('source-highlighter', 'highlightjs')
-                                .build()
-                )
-                .backend("html5")
-                .build()
-    }
-
-    def cleanup() {
-        asciidoctor.shutdown()
-    }
+class ConfigurationPropertiesMacroSpec extends AbstractConverterSpec {
 
     def "converts properties"() {
         when:
@@ -116,7 +89,4 @@ mongodb {
 </div>'''
     }
 
-    void convert(String input) {
-        converted = asciidoctor.convert(input, options)
-    }
 }

--- a/src/test/groovy/io/micronaut/docs/JdkApiMacroSpec.groovy
+++ b/src/test/groovy/io/micronaut/docs/JdkApiMacroSpec.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.docs
+
+class JdkApiMacroSpec extends AbstractConverterSpec {
+    def "converts JDK link using default module"() {
+        when:
+        convert "jdk:java.util.concurrent.CompletableFuture[]"
+
+        then:
+        converted.contains '<a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/CompletableFuture.html">CompletableFuture</a>'
+    }
+
+    def "can specify a module explicitly"() {
+        when:
+        convert "jdk:java.util.logging.ConsoleHandler[module=java.logging]"
+
+        then:
+        converted.contains '<a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.logging/java/util/logging/ConsoleHandler.html">ConsoleHandler</a>'
+    }
+}


### PR DESCRIPTION
Since Java 17, the links to the JDK classes must include their module. This commit fixes the macro so that all classes which package starts with `java` are assigned the `java.base` module automatically, but makes it possible to specify their module explicitly by using the `[module=....]` attribute.

Fixes #605