### PR TITLE
Allow configuration of JDK to execute tests under

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ tasks.register('functionalTest', Test) {
     inputs.dir(file("src/functionalTest/gradle-projects"))
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
+    systemProperty "CURRENT_JDK", JavaVersion.current().majorVersion
 }
 
 tasks.named('check') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=6.5.8-SNAPSHOT
+projectVersion=6.6.0-SNAPSHOT
 title=Micronaut Build Plugins
 projectDesc=Micronaut internal Gradle plugins. Not intended to be used in user's projects
 projectUrl=https://micronaut.io

--- a/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
+++ b/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
@@ -22,6 +22,26 @@ class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
         outputContains "Java version: 17"
     }
 
+    void "test java defaults to current JDK"() {
+        given:
+        withSample("test-micronaut-module")
+
+        file("subproject1/build.gradle") << """
+            tasks.register("printJavaVersion") {
+                doLast {
+                    println "Java version: \${micronautBuild.testJavaVersion.get()}"
+                }
+            }
+        """
+
+        when:
+        debug = true
+        run 'printJavaVersion'
+
+        then:
+        outputContains "Java version: ${System.getProperty('CURRENT_JDK')}"
+    }
+
    void "warns if using #property compatibility"() {
         given:
         withSample("test-micronaut-module")

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -164,7 +164,7 @@ You can do this directly in the project, or, better, in a convention plugin if i
                 enabled = false
             }
             javaLauncher.set(toolchains.launcherFor {
-                languageVersion.set(micronautBuildExtension.testJavaVersion.map {  JavaLanguageVersion.of(it.majorVersion) })
+                languageVersion.set(micronautBuildExtension.testJavaVersion.map { JavaLanguageVersion.of(it) })
             })
         }
 

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -16,6 +16,7 @@ import org.gradle.api.tasks.javadoc.Groovydoc
 import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.tasks.Jar
 import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
 
 import static io.micronaut.build.BomSupport.coreBomArtifactId
 import static io.micronaut.build.utils.VersionHandling.versionProviderOrDefault
@@ -117,6 +118,8 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
         project.apply plugin: "java-library"
 
         def javaPluginExtension = project.extensions.findByType(JavaPluginExtension)
+        JavaToolchainService toolchains = project.getExtensions().getByType(JavaToolchainService.class);
+
         javaPluginExtension.toolchain.languageVersion.convention(micronautBuildExtension.javaVersion.map(JavaLanguageVersion::of))
         project.afterEvaluate {
             if (micronautBuildExtension.sourceCompatibility.isPresent() || micronautBuildExtension.targetCompatibility.isPresent()) {
@@ -160,6 +163,9 @@ You can do this directly in the project, or, better, in a convention plugin if i
             distribution {
                 enabled = false
             }
+            javaLauncher.set(toolchains.launcherFor {
+                languageVersion.set(micronautBuildExtension.testJavaVersion.map {  JavaLanguageVersion.of(it.majorVersion) })
+            })
         }
 
         project.tasks.withType(GroovyCompile).configureEach {

--- a/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -4,10 +4,12 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import io.micronaut.build.pom.BomSuppressions;
 import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Nested;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
 import javax.inject.Inject;
 
@@ -32,6 +34,7 @@ public abstract class MicronautBuildExtension {
     this.compileOptions = getObjects().newInstance(MicronautCompileOptions.class);
 
     getJavaVersion().convention(DEFAULT_JAVA_VERSION);
+    getTestJavaVersion().convention(JavaLanguageVersion.of(JavaVersion.current().getMajorVersion()));
     getCheckstyleVersion().convention(DEFAULT_CHECKSTYLE_VERSION);
     getDependencyUpdatesPattern().convention(DEFAULT_DEPENDENCY_UPDATES_PATTERN);
     getEnforcedPlatform().convention(false);
@@ -57,6 +60,12 @@ public abstract class MicronautBuildExtension {
    * @return the java version for this project
    */
   public abstract Property<Integer> getJavaVersion();
+
+  /**
+   * The version of Java for running the tests. Defaults to JavaVersion.current().
+   * @return the java version for this project
+   */
+  public abstract Property<JavaLanguageVersion> getTestJavaVersion();
 
   /**
    * The default source compatibility

--- a/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -34,7 +34,7 @@ public abstract class MicronautBuildExtension {
     this.compileOptions = getObjects().newInstance(MicronautCompileOptions.class);
 
     getJavaVersion().convention(DEFAULT_JAVA_VERSION);
-    getTestJavaVersion().convention(JavaLanguageVersion.of(JavaVersion.current().getMajorVersion()));
+    getTestJavaVersion().convention(Integer.valueOf(JavaVersion.current().getMajorVersion()));
     getCheckstyleVersion().convention(DEFAULT_CHECKSTYLE_VERSION);
     getDependencyUpdatesPattern().convention(DEFAULT_DEPENDENCY_UPDATES_PATTERN);
     getEnforcedPlatform().convention(false);
@@ -65,7 +65,7 @@ public abstract class MicronautBuildExtension {
    * The version of Java for running the tests. Defaults to JavaVersion.current().
    * @return the java version for this project
    */
-  public abstract Property<JavaLanguageVersion> getTestJavaVersion();
+  public abstract Property<Integer> getTestJavaVersion();
 
   /**
    * The default source compatibility


### PR DESCRIPTION
Defaults to the JavaVersion.current() that is running the build