### PR TITLE
Improve binary compatiblity activation

### DIFF
--- a/src/main/groovy/io/micronaut/build/compat/AbstractBinaryCompatibilityExtension.java
+++ b/src/main/groovy/io/micronaut/build/compat/AbstractBinaryCompatibilityExtension.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.compat;
+
+import org.gradle.api.provider.Provider;
+
+public abstract class AbstractBinaryCompatibilityExtension implements BinaryCompatibibilityExtension {
+    private final Provider<String> projectVersion;
+
+    public AbstractBinaryCompatibilityExtension(Provider<String> projectVersion) {
+        this.projectVersion = projectVersion;
+    }
+
+    @Override
+    public void enabledAfter(String releaseVersion) {
+        getEnabled().set(projectVersion.map(version -> {
+            String[] tokens = releaseVersion.split("[.]");
+            if (tokens.length != 3) {
+                throw new IllegalArgumentException("Release version must consist of 3 parts: major.minor.bugfix but was: " + releaseVersion);
+            }
+            if (version.indexOf("-") > 0) {
+                version = version.substring(0, version.indexOf("-"));
+            }
+            String[] projectVersionTokens = version.split("[.]");
+            if (projectVersionTokens.length != 3) {
+                throw new IllegalArgumentException("Project version must consist of 3 parts: major.minor.bugfix but was: " + version);
+            }
+            int projectMajor = Integer.parseInt(projectVersionTokens[0]);
+            int projectMinor = Integer.parseInt(projectVersionTokens[1]);
+            int projectBugfix = Integer.parseInt(projectVersionTokens[2]);
+            int releaseMajor = Integer.parseInt(tokens[0]);
+            int releaseMinor = Integer.parseInt(tokens[1]);
+            int releaseBugfix = Integer.parseInt(tokens[2]);
+            return (projectMajor > releaseMajor)
+                || (projectMajor == releaseMajor && projectMinor > releaseMinor)
+                || (projectMajor == releaseMajor && projectMinor == releaseMinor && projectBugfix > releaseBugfix);
+        }));
+
+
+    }
+}

--- a/src/main/groovy/io/micronaut/build/compat/BinaryCompatibibilityExtension.java
+++ b/src/main/groovy/io/micronaut/build/compat/BinaryCompatibibilityExtension.java
@@ -22,4 +22,5 @@ public interface BinaryCompatibibilityExtension {
     RegularFileProperty getAcceptedRegressionsFile();
     Property<Boolean> getEnabled();
     Property<String> getBaselineVersion();
+    void enabledAfter(String releaseVersion);
 }

--- a/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
+++ b/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
@@ -50,7 +50,12 @@ public class MicronautBinaryCompatibilityPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getPlugins().apply(MicronautBuildExtensionPlugin.class);
         MicronautBuildExtension extension = project.getExtensions().getByType(MicronautBuildExtension.class);
-        BinaryCompatibibilityExtension binaryCompatibility = ((ExtensionAware) extension).getExtensions().create("binaryCompatibility", BinaryCompatibibilityExtension.class);
+        BinaryCompatibibilityExtension binaryCompatibility = ((ExtensionAware) extension).getExtensions().create(
+            BinaryCompatibibilityExtension.class,
+            "binaryCompatibility",
+            AbstractBinaryCompatibilityExtension.class,
+            project.getProviders().provider(() -> String.valueOf(project.getVersion()))
+        );
         binaryCompatibility.getAcceptedRegressionsFile().convention(
                 project.getRootProject().getLayout().getProjectDirectory().file("config/accepted-api-changes.json")
         );

--- a/src/test/groovy/io/micronaut/build/compat/BinaryCompatibilityExtensionTest.groovy
+++ b/src/test/groovy/io/micronaut/build/compat/BinaryCompatibilityExtensionTest.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.build.compat
+
+import io.micronaut.build.MicronautPublishingPlugin
+import org.gradle.api.plugins.JavaLibraryPlugin
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class BinaryCompatibilityExtensionTest extends Specification {
+    def "can disable binary compatibility for specific releases"() {
+        def project = ProjectBuilder.builder().build()
+        project.pluginManager.apply(JavaLibraryPlugin)
+        project.pluginManager.apply(MicronautPublishingPlugin)
+        project.pluginManager.apply(MicronautBinaryCompatibilityPlugin)
+
+        when:
+        project.version = projectVersion
+        project.micronautBuild.binaryCompatibility.enabledAfter testVersion
+
+        then:
+        project.micronautBuild.binaryCompatibility.enabled.get() == enabled
+
+        where:
+        projectVersion | testVersion | enabled
+        '1.0.0'        | '0.9.0'     | true
+        '1.0.0'        | '1.1.0'     | false
+        '1.0.0'        | '1.1.0'     | false
+        '1.0.1'        | '1.0.0'     | true
+        '1.1.0'        | '1.0.0'     | true
+        '2.0.0'        | '1.0.0'     | true
+
+    }
+}


### PR DESCRIPTION
Often when a new module is added to a project, we need to disable binary compatibility checks for that module, because there's no previous release yet. To do this, developers often chose the easy way, which is to set `enabled = false` to the binary compatibility extension.

However, it is easy to forget to re-enable binary compatibility checks after a release. This PR adds a new method to the binary compatibility extension to express the fact that binary checks should be enabled once release X is done.

For example, instead of writing:

```java
micronautBuild {
    binaryCompatibility {
        String v = projectVersion - '-SNAPSHOT'
        def (int major, int minor, int patch) = (v.split(/[.]/) as List).collect { Integer.parseInt(it) }
        enabled = major > 2 || (major == 2 && minor > 2) || (major == 2 && minor == 2 && patch > 0)
    }
}
```

one can now simply write:

```java
micronautBuild {
    binaryCompatibility {
        enabledAfter '2.2.0'
    }
}
```