### PR TITLE
Fixed caching for JapiCmp tasks which was caused by an absolute path.

### DIFF
--- a/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
+++ b/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
@@ -100,13 +100,14 @@ public class MicronautBinaryCompatibilityPlugin implements Plugin<Project> {
                     Task effectiveJar = jar;
                     japicmpTask.configure(task -> {
                         File changesFile = binaryCompatibility.getAcceptedRegressionsFile().get().getAsFile();
+                        String changesFileRelativePath = changesFile.toPath().relativize(p.getBuildFile().toPath()).toString();
                         if (changesFile.exists()) {
                             task.getInputs().file(changesFile).withPropertyName("accepted-api-changes").withPathSensitivity(PathSensitivity.NONE).optional(true);
                         }
                         task.getNewArchives().from(effectiveJar);
                         task.richReport(report ->
                                 report.addViolationTransformer(AcceptedApiChangesRule.class,
-                                        Collections.singletonMap(AcceptedApiChangesRule.CHANGES_FILE, changesFile.getAbsolutePath())
+                                        Collections.singletonMap(AcceptedApiChangesRule.CHANGES_FILE, changesFileRelativePath)
                                 )
                         );
                     });


### PR DESCRIPTION
Fixed caching for JapiCmp tasks which was caused by an absolute path.

This was visible in most (if not all) micronaut project, such as with [micronaut-data](https://ge.solutions-team.gradle.com/c/prvolmj2n4zwc/nj6vniinu4vvw/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure), where we see there's a difference in richReport.rules property. I've narrowed it down to an absolute path, after fixing which we get all the JapiCmp tasks [FROM-CACHE](https://ge.solutions-team.gradle.com/s/ve4s7gnwbe6zc/timeline?hide-timeline&type=me.champeau.gradle.japicmp.JapicmpTask).