### PR TITLE
fix: JavaDocAtValueReplacementTask and generic classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ tasks.register('functionalTest', Test) {
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
     systemProperty "CURRENT_JDK", JavaVersion.current().majorVersion
+    environment("GH_USERNAME", System.getenv("GH_USERNAME"))
+    environment("GH_TOKEN_PUBLIC_REPOS_READONLY", System.getenv("GH_TOKEN_PUBLIC_REPOS_READONLY"))
+    environment("CI", System.getenv("CI"))
 }
 
 tasks.named('check') {

--- a/src/functionalTest/gradle-projects/test-micronaut-module/subproject1/src/main/java/io/micronaut/subproject1/GenericConfig.java
+++ b/src/functionalTest/gradle-projects/test-micronaut-module/subproject1/src/main/java/io/micronaut/subproject1/GenericConfig.java
@@ -1,0 +1,26 @@
+package io.micronaut.subproject1;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+@ConfigurationProperties(GenericConfig.PREFIX)
+public class GenericConfig<T> {
+
+    public static final String PREFIX = "generic";
+    public static final int DEFAULT_VALUE = 234;
+
+    /**
+     * @return the config value
+     */
+    public int getConfig() {
+        return DEFAULT_VALUE;
+    }
+
+    /**
+     * Generic config default value is {@value GenericConfig#DEFAULT_VALUE}.
+     *
+     * @param config
+     */
+    public void setConfig(int config) {
+        // no-op
+    }
+}

--- a/src/functionalTest/gradle-projects/test-micronaut-module/subproject1/src/main/java/io/micronaut/subproject1/NormalConfig.java
+++ b/src/functionalTest/gradle-projects/test-micronaut-module/subproject1/src/main/java/io/micronaut/subproject1/NormalConfig.java
@@ -1,0 +1,26 @@
+package io.micronaut.subproject1;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+@ConfigurationProperties(NormalConfig.PREFIX)
+public class NormalConfig {
+
+    public static final String PREFIX = "normal";
+    public static final int DEFAULT_VALUE = 42;
+
+    /**
+     * @return the config value
+     */
+    public int getConfig() {
+        return DEFAULT_VALUE;
+    }
+
+    /**
+     * Normal config default value is {@value NormalConfig#DEFAULT_VALUE}.
+     *
+     * @param config
+     */
+    public void setConfig(int config) {
+        // no-op
+    }
+}

--- a/src/functionalTest/groovy/io/micronaut/build/docs/ConfigPropertiesTest.groovy
+++ b/src/functionalTest/groovy/io/micronaut/build/docs/ConfigPropertiesTest.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.build.docs
+
+import io.micronaut.build.AbstractFunctionalTest
+
+import java.nio.file.Files
+
+class ConfigPropertiesTest extends AbstractFunctionalTest {
+
+    void "@Value in javadoc works as expected"() {
+        given:
+        withSample("test-micronaut-module")
+        println testDirectory.toFile()
+
+        and: 'we copy the grails-doc-files.jar to the prepareDocsResources directory'
+        def path = Files.createDirectories(testDirectory.resolve("build/tmp/prepareDocsResources"))
+        def stream = ConfigPropertiesTest.getResourceAsStream("/grails-doc-files.jar")
+        def target = path.resolve("grails-doc-files.jar")
+        Files.copy(stream, target)
+
+        when: 'we build the docs'
+        run 'docs'
+
+        then:
+        with(testDirectory.resolve("build/docs/guide/configurationreference.html").text) {
+            contains("Generic config default value is 234.")
+            contains("Normal config default value is 42.")
+        }
+    }
+}

--- a/src/main/java/io/micronaut/build/docs/props/JavaDocAtValueReplacementTask.java
+++ b/src/main/java/io/micronaut/build/docs/props/JavaDocAtValueReplacementTask.java
@@ -35,10 +35,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @CacheableTask
 public abstract class JavaDocAtValueReplacementTask extends DefaultTask {
+
+    private static final Pattern JAVA_CLASSNAME_PATTERN = Pattern.compile("(\\p{javaJavaIdentifierPart}+).*");
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -132,16 +136,18 @@ public abstract class JavaDocAtValueReplacementTask extends DefaultTask {
                 for (String line : lines) {
                     if (line.contains("class ")) {
                         String subLine = line.substring(line.indexOf("class ") + "class ".length());
-                        if (subLine.indexOf(' ') != -1) {
-                            classEvaluated = subLine.substring(0, subLine.indexOf(' '));
+                        Matcher matcher = JAVA_CLASSNAME_PATTERN.matcher(subLine);
+                        if (matcher.find()) {
+                            classEvaluated = matcher.group(1);
                         } else {
                             classEvaluated = subLine;
                         }
                     }
                     if (line.contains("interface ")) {
                         String subLine = line.substring(line.indexOf("interface ") + "interface ".length());
-                        if (subLine.indexOf(' ') != -1) {
-                            interfaceEvaluated = subLine.substring(0, subLine.indexOf(' '));
+                        Matcher matcher = JAVA_CLASSNAME_PATTERN.matcher(subLine);
+                        if (matcher.find()) {
+                            interfaceEvaluated = matcher.group(1);
                         } else {
                             interfaceEvaluated = subLine;
                         }


### PR DESCRIPTION
When we specify a value (for example as a default), this task searches for this value and replaces it in the docs.

This wasn't working for generics as it relied on a space after the class name.

[Spotted in this class in our EclipseStore module](https://github.com/micronaut-projects/micronaut-eclipsestore/blob/add-caching/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/EclipseStoreCacheConfigurationProperties.java)