### PR TITLE
Allow Groovy version to be from micronaut-core

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -38,7 +38,8 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
 
     private void configureDependencies(Project project, MicronautBuildExtension micronautBuild) {
         def micronautVersionProvider = versionProviderOrDefault(project, 'micronaut', '')
-        def groovyVersionProvider = versionProviderOrDefault(project, 'groovy', '')
+        // The Groovy version comes from core if not defined locally
+        def groovyVersionProvider = versionProviderOrDefault(project, 'groovy', List.of("libs", "mn"), '')
         def groovyGroupProvider = groovyVersionProvider.map { groovyVersion ->
             groovyVersion.split("\\.").first().toInteger() <= 3 ?
                     'org.codehaus.groovy' :


### PR DESCRIPTION
We only want to define the Groovy version in core, and not in every module.

Currently, the internal plugins look for the groovy version in the module catalog, or properties.

This PR extends where we look for a Groovy version, so it will check the local catalog, and then the micronaut-core catalog for the version (and then the properties if not found in either)