### PR TITLE
Add ability to reject versions by regular expression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,9 @@ tasks.register('functionalTest', Test) {
     systemProperty "CURRENT_JDK", JavaVersion.current().majorVersion
     environment("GH_USERNAME", System.getenv("GH_USERNAME"))
     environment("GH_TOKEN_PUBLIC_REPOS_READONLY", System.getenv("GH_TOKEN_PUBLIC_REPOS_READONLY"))
-    environment("CI", System.getenv("CI"))
+    if (System.getenv("CI") != null) {
+        environment("CI", System.getenv("CI"))
+    }
 }
 
 tasks.named('check') {

--- a/src/functionalTest/groovy/io/micronaut/build/catalogs/VersionCatalogUpdateFunctionalTest.groovy
+++ b/src/functionalTest/groovy/io/micronaut/build/catalogs/VersionCatalogUpdateFunctionalTest.groovy
@@ -69,6 +69,13 @@ class VersionCatalogUpdateFunctionalTest extends AbstractFunctionalTest {
         repository.when(
                 request()
         ).respond(new LoggingCallback())
+        if (idx == 7) {
+            buildFile << """
+                tasks.named("updateVersionCatalogs") {
+                    rejectedVersionsPerModule['awesome.lib:awesome'] = '3\\\\.0\\\\.[8-9]'
+                }
+            """
+        }
         run 'useLatestVersions'
 
         then:
@@ -88,7 +95,7 @@ class VersionCatalogUpdateFunctionalTest extends AbstractFunctionalTest {
         catalogFile.text == expected
 
         where:
-        idx << (0..6)
+        idx << (0..7)
     }
 
     static class LoggingCallback implements ExpectationResponseCallback {

--- a/src/functionalTest/resources/io/micronaut/build/catalogs/VersionCatalogUpdateFunctionalTest/initial-7.versions.toml
+++ b/src/functionalTest/resources/io/micronaut/build/catalogs/VersionCatalogUpdateFunctionalTest/initial-7.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+awesome = "3.0.6"
+
+[libraries]
+awesome = { module = "awesome.lib:awesome", version.ref = "awesome" }

--- a/src/functionalTest/resources/io/micronaut/build/catalogs/VersionCatalogUpdateFunctionalTest/updated-7.versions.toml
+++ b/src/functionalTest/resources/io/micronaut/build/catalogs/VersionCatalogUpdateFunctionalTest/updated-7.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+awesome = "3.0.7"
+
+[libraries]
+awesome = { module = "awesome.lib:awesome", version.ref = "awesome" }

--- a/src/functionalTest/resources/repository/awesome/lib/awesome/3.0.7/awesome-3.0.7.pom
+++ b/src/functionalTest/resources/repository/awesome/lib/awesome/3.0.7/awesome-3.0.7.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>awesome.lib</groupId>
+    <artifactId>awesome</artifactId>
+    <version>3.0.7</version>
+    <packaging>jar</packaging>
+</project>

--- a/src/main/java/io/micronaut/build/catalogs/MicronautVersionCatalogUpdatePlugin.java
+++ b/src/main/java/io/micronaut/build/catalogs/MicronautVersionCatalogUpdatePlugin.java
@@ -26,6 +26,7 @@ public class MicronautVersionCatalogUpdatePlugin implements Plugin<Project> {
             task.getOutputDirectory().convention(project.getLayout().getBuildDirectory().dir("catalogs-update"));
             task.getRejectedQualifiers().convention(Arrays.asList("alpha", "beta", "rc", "cr", "m", "preview", "b", "ea"));
             task.getIgnoredModules().convention(Collections.emptySet());
+            task.getRejectedVersionsPerModule().convention(Collections.emptyMap());
             task.getAllowMajorUpdates().convention(false);
         });
         tasks.register("useLatestVersions", Copy.class, task -> {


### PR DESCRIPTION
For each module, it is now possible to exclude some versions from upgrades, for example:

```gradle
tasks.named("updateVersionCatalogs") {
    rejectedVersionsPerModule['awesome.lib:awesome'] = '3[.]0.[8-9]'
}
```
