### PR TITLE
Upgrade to Develocity plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'groovy-gradle-plugin'
     id 'groovy'
     id 'maven-publish'
-    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
     id 'signing'
 }
 
@@ -63,7 +63,7 @@ dependencies {
     implementation libs.nexus.publish.plugin
     implementation libs.sonar.plugin
 
-    implementation libs.gradle.enterprise.plugin
+    implementation libs.develocity.plugin
     implementation libs.gradle.github.actions.plugin
     implementation libs.gradle.custom.userdata.plugin
     implementation libs.japicmp.plugin
@@ -159,6 +159,10 @@ gradlePlugin {
         gradleEnterprise {
             id = 'io.micronaut.build.internal.gradle-enterprise'
             implementationClass = 'io.micronaut.build.MicronautGradleEnterprisePlugin'
+        }
+        develocity {
+            id = 'io.micronaut.build.internal.develocity'
+            implementationClass = 'io.micronaut.build.MicronautDevelocityPlugin'
         }
         sharedSettings {
             id = 'io.micronaut.build.shared.settings'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=6.7.2-SNAPSHOT
+projectVersion=7.0.0-SNAPSHOT
 title=Micronaut Build Plugins
 projectDesc=Micronaut internal Gradle plugins. Not intended to be used in user's projects
 projectUrl=https://micronaut.io

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,11 @@ asciidoctorj = "2.5.12"
 commons-lang3 = "3.14.0"
 japicmp-plugin = "0.4.2"
 gradle-custom-userdata-plugin = "2.0.1"
-gradle-enterprise-plugin = "3.17.2"
-gradle-github-actions-plugin = "1.3.2"
+develocity-plugin = "3.17.2"
+gradle-github-actions-plugin = "1.4.0"
 grails-gdoc = "1.0.1"
 mockserver = "5.15.0"
-nexus-publish-plugin = "1.3.0"
+nexus-publish-plugin = "2.0.0"
 snakeyaml = "2.2"
 sonar-plugin = "4.0.0.2929"
 spock = "2.1-groovy-3.0"
@@ -24,7 +24,7 @@ bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 japicmp-plugin = { module = "me.champeau.gradle:japicmp-gradle-plugin", version.ref = "japicmp-plugin" }
 gradle-custom-userdata-plugin = { module = "com.gradle:common-custom-user-data-gradle-plugin", version.ref = "gradle-custom-userdata-plugin" }
-gradle-enterprise-plugin = { module = "com.gradle:gradle-enterprise-gradle-plugin", version.ref = "gradle-enterprise-plugin" }
+develocity-plugin = { module = "com.gradle:develocity-gradle-plugin", version.ref = "develocity-plugin" }
 gradle-github-actions-plugin = { module = "org.nosphere.gradle.github:gradle-github-actions-plugin", version.ref = "gradle-github-actions-plugin" }
 grails-gdoc = { module = "org.grails:grails-gdoc-engine", version.ref = "grails-gdoc" }
 nexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexus-publish-plugin" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,13 +1,14 @@
 plugins {
-    id "com.gradle.enterprise" version "3.17.2"
+    id "com.gradle.develocity" version "3.17.2"
 }
 
 rootProject.name = 'micronaut-build'
 
-gradleEnterprise {
+develocity {
     server = "https://ge.micronaut.io"
     buildScan {
-        publishAlways()
-        publishIfAuthenticated()
+        publishing {
+            onlyIf { context -> context.authenticated }
+        }
     }
 }

--- a/src/main/java/io/micronaut/build/MicronautDevelocityPlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautDevelocityPlugin.java
@@ -31,8 +31,8 @@ import org.nosphere.gradle.github.ActionsPlugin;
 import static io.micronaut.build.BuildEnvironment.PREDICTIVE_TEST_SELECTION_ENV_VAR;
 
 public class MicronautDevelocityPlugin implements Plugin<Settings> {
-    private static final String[] SAFE_TO_LOG_ENV_VARIABLES = new String[] {
-            PREDICTIVE_TEST_SELECTION_ENV_VAR
+    private static final String[] SAFE_TO_LOG_ENV_VARIABLES = new String[]{
+        PREDICTIVE_TEST_SELECTION_ENV_VAR
     };
 
     @Override
@@ -70,9 +70,7 @@ public class MicronautDevelocityPlugin implements Plugin<Settings> {
                                      DevelocityConfiguration config,
                                      MicronautBuildSettingsExtension micronautBuildSettingsExtension) {
         var providers = settings.getProviders();
-        var publishScanOnDemand = providers.gradleProperty("publishScanOnDemand")
-                .map(Boolean::parseBoolean)
-                .orElse(false);
+        var publishScanOnDemand = booleanProperty(settings, "publishScanOnDemand", false);
         var isCI = ProviderUtils.guessCI(providers);
         var buildScanExplicit = settings.getStartParameter().isBuildScan();
         configureBuildScansPublishing(config, isCI, publishScanOnDemand, buildScanExplicit);
@@ -137,17 +135,16 @@ public class MicronautDevelocityPlugin implements Plugin<Settings> {
 
     private void configureBuildScansPublishing(DevelocityConfiguration config,
                                                boolean isCI,
-                                               Provider<Boolean> publishScanOnDemand,
+                                               boolean publishScanOnDemand,
                                                boolean buildScanExplicit) {
         config.getServer().convention("https://ge.micronaut.io");
         config.buildScan(buildScan -> {
             buildScan.getPublishing().onlyIf(context -> {
-                if (Boolean.TRUE.equals(publishScanOnDemand.get())) {
+                if (publishScanOnDemand) {
                     return buildScanExplicit;
                 }
-                return  isCI || context.isAuthenticated();
+                return isCI || context.isAuthenticated();
             });
-            buildScan.capture(c -> c.getFileFingerprints().convention(true));
         });
     }
 

--- a/src/main/java/io/micronaut/build/MicronautDevelocityPlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautDevelocityPlugin.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+import com.gradle.CommonCustomUserDataGradlePlugin;
+import com.gradle.develocity.agent.gradle.DevelocityConfiguration;
+import com.gradle.develocity.agent.gradle.DevelocityPlugin;
+import io.micronaut.build.utils.ProviderUtils;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Plugin;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.caching.configuration.BuildCacheConfiguration;
+import org.nosphere.gradle.github.ActionsPlugin;
+
+import static io.micronaut.build.BuildEnvironment.PREDICTIVE_TEST_SELECTION_ENV_VAR;
+
+public class MicronautDevelocityPlugin implements Plugin<Settings> {
+    private static final String[] SAFE_TO_LOG_ENV_VARIABLES = new String[] {
+            PREDICTIVE_TEST_SELECTION_ENV_VAR
+    };
+
+    @Override
+    public void apply(Settings settings) {
+        if (!isDevelocityEnabled(settings)) {
+            return;
+        }
+        var pluginManager = settings.getPluginManager();
+        pluginManager.apply(MicronautBuildSettingsPlugin.class);
+        pluginManager.apply(DevelocityPlugin.class);
+        pluginManager.apply(CommonCustomUserDataGradlePlugin.class);
+        Provider<String> projectGroup = settings.getProviders().gradleProperty("projectGroup");
+        if (projectGroup.isPresent() && !projectGroup.get().startsWith("io.micronaut")) {
+            // Do not apply the Gradle Enterprise plugin if the project doesn't belong to
+            // our own group
+            return;
+        }
+        var config = settings.getExtensions().getByType(DevelocityConfiguration.class);
+        var micronautBuildSettingsExtension = settings.getExtensions().getByType(MicronautBuildSettingsExtension.class);
+        configureDevelocity(settings, config, micronautBuildSettingsExtension);
+    }
+
+    private static boolean isDevelocityEnabled(Settings settings) {
+        return booleanProperty(settings, "develocity.enabled", true);
+    }
+
+    private static boolean booleanProperty(Settings settings, String name, boolean defaultValue) {
+        return settings.getProviders()
+            .gradleProperty(name)
+            .map(Boolean::parseBoolean)
+            .getOrElse(defaultValue);
+    }
+
+    private void configureDevelocity(Settings settings,
+                                     DevelocityConfiguration config,
+                                     MicronautBuildSettingsExtension micronautBuildSettingsExtension) {
+        var providers = settings.getProviders();
+        var publishScanOnDemand = providers.gradleProperty("publishScanOnDemand")
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+        var isCI = ProviderUtils.guessCI(providers);
+        var buildScanExplicit = settings.getStartParameter().isBuildScan();
+        configureBuildScansPublishing(config, isCI, publishScanOnDemand, buildScanExplicit);
+        settings.getGradle().projectsLoaded(MicronautDevelocityPlugin::applyGitHubActionsPlugin);
+        tagWithJavaDetails(config, providers);
+        if (booleanProperty(settings, "org.gradle.caching", true)) {
+            configureBuildCache(settings, config, micronautBuildSettingsExtension, providers, isCI);
+        }
+        var buildEnvironment = new BuildEnvironment(providers);
+        if (Boolean.TRUE.equals(buildEnvironment.isTestSelectionEnabled().get())) {
+            config.getBuildScan().tag("Predictive Test Selection");
+        }
+        captureSafeEnvironmentVariables(config);
+    }
+
+    private static void configureBuildCache(Settings settings, DevelocityConfiguration config, MicronautBuildSettingsExtension micronautBuildSettingsExtension, ProviderFactory providers, boolean isCI) {
+        settings.getGradle().settingsEvaluated(lateSettings -> {
+            BuildCacheConfiguration buildCache = settings.getBuildCache();
+            boolean localEnabled = micronautBuildSettingsExtension.getUseLocalCache().get();
+            boolean remoteEnabled = micronautBuildSettingsExtension.getUseRemoteCache().get();
+            boolean push = MicronautBuildSettingsExtension.booleanProvider(providers, "cachePush", isCI).get();
+            if (isCI) {
+                System.out.println("Build cache     enabled     push");
+                System.out.println("    Local        " + (localEnabled ? "   Y   " : "   N   ") + "     N/A");
+                System.out.println("    Remote       " + (remoteEnabled ? "   Y   " : "   N   ") + "     " + (push ? " Y" : " N"));
+            }
+            buildCache.getLocal().setEnabled(localEnabled);
+            if (remoteEnabled) {
+                configureRemoteCache(config, buildCache, push, providers);
+            }
+        });
+    }
+
+    private static void configureRemoteCache(DevelocityConfiguration config, BuildCacheConfiguration buildCache, boolean push, ProviderFactory providers) {
+        buildCache.remote(config.getBuildCache(), remote -> {
+            remote.setEnabled(true);
+            if (push) {
+                String accessKey = providers.systemProperty("GRADLE_ENTERPRISE_ACCESS_KEY").getOrNull();
+                if (accessKey != null && !accessKey.isEmpty()) {
+                    remote.setPush(true);
+                } else {
+                    System.err.println("WARNING: Access key missing for remote build cache, cannot configure push!");
+                }
+            }
+        });
+    }
+
+    private void tagWithJavaDetails(DevelocityConfiguration ge, ProviderFactory providers) {
+        var vendor = providers.systemProperty("java.vendor");
+        if (vendor.isPresent()) {
+            ge.getBuildScan().tag("vendor:" + vendor.get().toLowerCase().replaceAll("\\W+", "_"));
+        }
+        ge.getBuildScan().tag("jdk:" + JavaVersion.current().getMajorVersion());
+    }
+
+    private void captureSafeEnvironmentVariables(DevelocityConfiguration ge) {
+        for (var variable : SAFE_TO_LOG_ENV_VARIABLES) {
+            String value = System.getenv(variable);
+            ge.getBuildScan().value("env." + variable, value == null ? "<undefined>" : value);
+        }
+    }
+
+    private void configureBuildScansPublishing(DevelocityConfiguration config,
+                                               boolean isCI,
+                                               Provider<Boolean> publishScanOnDemand,
+                                               boolean buildScanExplicit) {
+        config.getServer().convention("https://ge.micronaut.io");
+        config.buildScan(buildScan -> {
+            buildScan.getPublishing().onlyIf(context -> {
+                if (Boolean.TRUE.equals(publishScanOnDemand.get())) {
+                    return buildScanExplicit;
+                }
+                return  isCI || context.isAuthenticated();
+            });
+            buildScan.capture(c -> c.getFileFingerprints().convention(true));
+        });
+    }
+
+    private static void applyGitHubActionsPlugin(Gradle gradle) {
+        gradle.getRootProject().getPluginManager().apply(ActionsPlugin.class);
+    }
+
+}

--- a/src/main/java/io/micronaut/build/MicronautGradleEnterprisePlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautGradleEnterprisePlugin.java
@@ -15,134 +15,18 @@
  */
 package io.micronaut.build;
 
-import com.gradle.CommonCustomUserDataGradlePlugin;
-import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
-import com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin;
-import com.gradle.scan.plugin.BuildScanExtension;
-import org.gradle.api.JavaVersion;
-import io.micronaut.build.utils.ProviderUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.initialization.Settings;
-import org.gradle.api.invocation.Gradle;
-import org.gradle.api.plugins.PluginManager;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.provider.ProviderFactory;
-import org.gradle.caching.configuration.BuildCacheConfiguration;
-import org.nosphere.gradle.github.ActionsPlugin;
-
-import java.lang.reflect.InvocationTargetException;
-
-import static io.micronaut.build.BuildEnvironment.PREDICTIVE_TEST_SELECTION_ENV_VAR;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MicronautGradleEnterprisePlugin implements Plugin<Settings> {
-    private static final String[] SAFE_TO_LOG_ENV_VARIABLES = new String[] {
-            PREDICTIVE_TEST_SELECTION_ENV_VAR
-    };
+    private static final Logger LOGGER = LoggerFactory.getLogger(MicronautGradleEnterprisePlugin.class);
 
     @Override
     public void apply(Settings settings) {
-        PluginManager pluginManager = settings.getPluginManager();
-        pluginManager.apply(MicronautBuildSettingsPlugin.class);
-        pluginManager.apply(GradleEnterprisePlugin.class);
-        pluginManager.apply(CommonCustomUserDataGradlePlugin.class);
-        Provider<String> projectGroup = settings.getProviders().gradleProperty("projectGroup");
-        if (projectGroup.isPresent() && !projectGroup.get().startsWith("io.micronaut")) {
-            // Do not apply the Gradle Enterprise plugin if the project doesn't belong to
-            // our own group
-            return;
-        }
-        GradleEnterpriseExtension ge = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
-        MicronautBuildSettingsExtension micronautBuildSettingsExtension = settings.getExtensions().getByType(MicronautBuildSettingsExtension.class);
-        configureGradleEnterprise(settings, ge, micronautBuildSettingsExtension);
-    }
-
-    private void configureGradleEnterprise(Settings settings,
-                                           GradleEnterpriseExtension ge,
-                                           MicronautBuildSettingsExtension micronautBuildSettingsExtension) {
-        ProviderFactory providers = settings.getProviders();
-        Provider<Boolean> publishScanOnDemand = providers.gradleProperty("publishScanOnDemand")
-                .map(Boolean::parseBoolean)
-                .orElse(false);
-        boolean isCI = ProviderUtils.guessCI(providers);
-        configureBuildScansPublishing(ge, isCI, publishScanOnDemand);
-        settings.getGradle().projectsLoaded(MicronautGradleEnterprisePlugin::applyGitHubActionsPlugin);
-        tagWithJavaDetails(ge, providers);
-        if (providers.gradleProperty("org.gradle.caching").map(Boolean::parseBoolean).orElse(true).get()) {
-            settings.getGradle().settingsEvaluated(lateSettings -> {
-                BuildCacheConfiguration buildCache = settings.getBuildCache();
-                boolean localEnabled = micronautBuildSettingsExtension.getUseLocalCache().get();
-                boolean remoteEnabled = micronautBuildSettingsExtension.getUseRemoteCache().get();
-                boolean push = MicronautBuildSettingsExtension.booleanProvider(providers, "cachePush", isCI).get();
-                if (isCI) {
-                    System.out.println("Build cache     enabled     push");
-                    System.out.println("    Local        " + (localEnabled ? "   Y   " : "   N   ") + "     N/A");
-                    System.out.println("    Remote       " + (remoteEnabled ? "   Y   " : "   N   ") + "     " + (push ? " Y" : " N"));
-                }
-                buildCache.getLocal().setEnabled(localEnabled);
-                if (remoteEnabled) {
-                    buildCache.remote(ge.getBuildCache(), remote -> {
-                        remote.setEnabled(true);
-                        if (push) {
-                            String accessKey = providers.systemProperty("GRADLE_ENTERPRISE_ACCESS_KEY").getOrNull();
-                            if (accessKey != null && !accessKey.isEmpty()) {
-                                remote.setPush(true);
-                            } else {
-                                System.err.println("WARNING: Access key missing for remote build cache, cannot configure push!");
-                            }
-                        }
-                    });
-                }
-            });
-            BuildEnvironment buildEnvironment = new BuildEnvironment(providers);
-            if (Boolean.TRUE.equals(buildEnvironment.isTestSelectionEnabled().get())) {
-                ge.getBuildScan().tag("Predictive Test Selection");
-            }
-            captureSafeEnvironmentVariables(ge);
-        }
-    }
-
-    private void tagWithJavaDetails(GradleEnterpriseExtension ge, ProviderFactory providers) {
-        Provider<String> vendor = providers.systemProperty("java.vendor");
-        if (vendor.isPresent()) {
-            ge.getBuildScan().tag("vendor:" + vendor.get().toLowerCase().replaceAll("\\W+", "_"));
-        }
-        ge.getBuildScan().tag("jdk:" + JavaVersion.current().getMajorVersion());
-    }
-
-    private void captureSafeEnvironmentVariables(GradleEnterpriseExtension ge) {
-        for (String variable : SAFE_TO_LOG_ENV_VARIABLES) {
-            String value = System.getenv(variable);
-            ge.getBuildScan().value("env." + variable, value == null ? "<undefined>" : value);
-        }
-    }
-
-    private void configureBuildScansPublishing(GradleEnterpriseExtension ge, boolean isCI, Provider<Boolean> publishScanOnDemand) {
-        ge.setServer("https://ge.micronaut.io");
-        ge.buildScan(buildScan -> {
-            if (!publishScanOnDemand.get()) {
-                buildScan.publishAlways();
-            }
-            if (isCI) {
-                buildScan.setUploadInBackground(false);
-            } else {
-                publishIfAuthenticated(buildScan);
-            }
-            buildScan.capture(c ->
-                    c.setTaskInputFiles(true)
-            );
-        });
-    }
-
-    private static void applyGitHubActionsPlugin(Gradle gradle) {
-        gradle.getRootProject().getPluginManager().apply(ActionsPlugin.class);
-    }
-
-    private static void publishIfAuthenticated(BuildScanExtension ext) {
-        try {
-            ext.getClass().getMethod("publishIfAuthenticated").invoke(ext);
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            System.err.println("Unable to set publish if authenticated on build scan extension");
-        }
+        LOGGER.warn("The io.micronaut.build.gradle-enterprise plugin is deprecated and will be removed in a future version. Please use the io.micronaut.build.develocity plugin instead.");
+        settings.getPluginManager().apply(MicronautDevelocityPlugin.class);
     }
 
 }

--- a/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
@@ -61,7 +61,7 @@ public class MicronautSharedSettingsPlugin implements MicronautPlugin<Settings> 
         PluginManager pluginManager = settings.getPluginManager();
         settings.getGradle().getSharedServices().registerIfAbsent(InternalStateCheckingService.NAME, InternalStateCheckingService.class, spec -> spec.parameters(p -> p.getRegisteredByProjectPlugin().set(false))).get();
         pluginManager.apply(MicronautBuildSettingsPlugin.class);
-        pluginManager.apply(MicronautGradleEnterprisePlugin.class);
+        pluginManager.apply(MicronautDevelocityPlugin.class);
         MicronautBuildSettingsExtension buildSettingsExtension = settings.getExtensions().findByType(MicronautBuildSettingsExtension.class);
         applyPublishingPlugin(settings);
         configureProjectNames(settings, buildSettingsExtension);


### PR DESCRIPTION
Our builds currently result in walls of Develocity deprecation warnings. This PR upgrades our builds to latest Develocity plugin. It also adds a property which can be set in `gradle.properties` to disable the plugin altogether.

In addition, this ugprades the nexus plugin to avoid build deprecations.

Given that it's a potential breaking change, I'm upgrading the major version to 7.0.