### PR TITLE
Fix documentation when default language is unavailable

### DIFF
--- a/src/main/template/js/multi-language-sample.js
+++ b/src/main/template/js/multi-language-sample.js
@@ -102,6 +102,14 @@ function postProcessCodeBlocks() {
         return string.charAt(0).toUpperCase() + string.slice(1);
     }
 
+    function ensureAtLeastOneCodeBlockIsVisible(collectionOfSampleElements) {
+        if (collectionOfSampleElements.length > 0 && collectionOfSampleElements.every(a => a.classList.contains("hidden"))) {
+            const firstElement = collectionOfSampleElements[0];
+            console.info("No code snippet in default preferred language, showing first", firstElement)
+            firstElement.classList.remove("hidden")
+        }
+    }
+
     function processSampleEl(sampleEl, prefLangId, prefBuildId, prefConfigId) {
         var codeEl = sampleEl.querySelector("code[data-lang]");
         if (codeEl != null) {
@@ -181,7 +189,7 @@ function postProcessCodeBlocks() {
                 processSampleEl(currentSampleElement, languageId, buildId, configId);
                 i++;
             }
-
+            ensureAtLeastOneCodeBlockIsVisible(currentCollection);
             multiLanguageSets.push(currentCollection);
         }
 


### PR DESCRIPTION
When a user views the documentation and clicks on a multi-lang snippet to view a specific language, we store that language in local-storage

So when they go to view another documentation doc, we remember what the language was, and select that one.

So someone who had selected Kotlin, sees Kotlin snippets when they go back later.

This had a bug in it. Sometimes when we add a multi-lang snippet we may only have a selection of languages covered in the tested source code. The issue is that when someone who has selected Kotlin previously lands on a page with a missing Kotlin snippet, they see no snippet as all are hidden.

See https://github.com/micronaut-projects/micronaut-data/issues/2896 for example

This PR introduces a new method which checks if a snippet group is all hidden, and if it is, it forces the first one to be visible