### PR TITLE
Add option to select catalog to use as source for the BOM

### DIFF
--- a/src/main/groovy/io/micronaut/build/pom/MicronautBomExtension.java
+++ b/src/main/groovy/io/micronaut/build/pom/MicronautBomExtension.java
@@ -32,6 +32,13 @@ import java.util.stream.Collectors;
  */
 public interface MicronautBomExtension {
     /**
+     * Specifies the name of the catalog to use.
+     * Defaults to "libs"
+     * @return the catalog to use
+     */
+    Property<String> getCatalogName();
+
+    /**
      * Excludes projects from the BOM. Any call to this
      * method will override the default spec which excludes
      * modules containing the name "bom" or starting with


### PR DESCRIPTION
This commit introduces a new "catalogName" property to the BOM extension, which defaults to "libs", and tells the BOM plugin which catalog to use for the BOM generation. This is required for the use case where multiple BOMs have to be generated, but using a different TOML file as source.