### PR TITLE
Fix multiple versions potentially accepted

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBasePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBasePlugin.groovy
@@ -21,6 +21,7 @@ import io.micronaut.build.docs.ConfigurationPropertiesPlugin
 import io.micronaut.build.graalvm.NativeImageSupportPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+
 /**
  * This plugin is responsible for creating the Micronaut Build
  * project extension and configuring reasonable defaults.
@@ -39,10 +40,14 @@ class MicronautBasePlugin implements Plugin<Project> {
     }
 
     private void configureProjectVersion(Project project) {
-        def version = project.providers.gradleProperty("projectVersion").orElse("undefined").get()
-        if (version.isEmpty() || !Character.isDigit(version.charAt(0))) {
-            throw new IllegalArgumentException("Version '" + version + "' is not a valid Micronaut version. It must start with a digit.")
-        }
+        def version = project.providers.gradleProperty("projectVersion")
+                .map(v -> {
+                    if (v.isEmpty() || !Character.isDigit(v.charAt(0))) {
+                        throw new IllegalArgumentException("Version '" + v + "' is not a valid Micronaut version. It must start with a digit.")
+                    }
+                    return v;
+                })
+                .orElse("undefined").get()
         project.version = version
     }
 

--- a/src/main/java/io/micronaut/build/catalogs/tasks/VersionCatalogUpdate.java
+++ b/src/main/java/io/micronaut/build/catalogs/tasks/VersionCatalogUpdate.java
@@ -289,6 +289,9 @@ public abstract class VersionCatalogUpdate extends DefaultTask {
                 if (!candidateDetails.isRejected()) {
                     processCandidate(candidateDetails);
                 }
+                if (candidateDetails.isAccepted()) {
+                    break;
+                }
                 if (!candidateDetails.isRejected() && !candidateDetails.hasFallback()) {
                     candidateDetails.acceptCandidate();
                     break;


### PR DESCRIPTION
This commit fixes an issue with version updates: when a custom implementation accepts a version, we should interrupt the loop otherwise it becomes possible for a lower version to be selected.