### PR TITLE
Support publishing of an included build

### DIFF
--- a/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
@@ -16,6 +16,7 @@
 package io.micronaut.build;
 
 import io.github.gradlenexus.publishplugin.NexusPublishExtension;
+import io.micronaut.build.utils.ProviderUtils;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Project;
 import org.gradle.api.initialization.ProjectDescriptor;
@@ -125,8 +126,8 @@ public class MicronautSharedSettingsPlugin implements MicronautPlugin<Settings> 
         String ossUser = envOrSystemProperty(providers, "SONATYPE_USERNAME", "sonatypeOssUsername", "");
         String ossPass = envOrSystemProperty(providers, "SONATYPE_PASSWORD", "sonatypeOssPassword", "");
         settings.getGradle().projectsLoaded(gradle -> {
-            String projectVersion = providers.gradleProperty("projectVersion").getOrElse("unspecified");
-            Provider<String> projectGroup = providers.gradleProperty("projectGroup");
+            String projectVersion = ProviderUtils.fromGradleProperty(providers, settings.getRootDir(), "projectVersion").getOrElse("undefined");
+            Provider<String> projectGroup = ProviderUtils.fromGradleProperty(providers, settings.getRootDir(), "projectGroup");
             gradle.getRootProject().getAllprojects().forEach(project -> {
                 project.setVersion(projectVersion);
                 if (projectGroup.isPresent()) {

--- a/src/main/java/io/micronaut/build/utils/IncludedBuildSupport.java
+++ b/src/main/java/io/micronaut/build/utils/IncludedBuildSupport.java
@@ -67,6 +67,7 @@ public class IncludedBuildSupport {
                     throw new RuntimeException(e);
                 }
                 newDigest = toHex(digest.digest());
+                Files.createDirectories(digestFile.getParent());
                 Files.writeString(digestFile, newDigest);
                 if (!newDigest.equals(previousDigest)) {
                     System.out.println("Catalog changed for " + githubProjectName + ": triggering build.");


### PR DESCRIPTION
This commit adds support for a special use case, which is currently only used in the Micronaut Fuzzing project, which is to publish a module which is an included build of a Micronaut repository. This module is also a Gradle plugin, which requires special setup. Therefore, this commit only makes sure that this use case is working.

It also fixes an issue with the "useDevelopmentVersion" code which failed if the `checkouts` directory wasn't created in advance.