### PR TITLE
Use Publisher API for publishing releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,10 @@ gradlePlugin {
             id = 'io.micronaut.build.internal.binary-compatibility-check'
             implementationClass = 'io.micronaut.build.compat.MicronautBinaryCompatibilityPlugin'
         }
+        parentPlugin {
+            id = 'io.micronaut.build.internal.parent'
+            implementationClass = 'io.micronaut.build.MicronautParentPublishingPlugin'
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=7.5.1-SNAPSHOT
+projectVersion=7.6.0-SNAPSHOT
 title=Micronaut Build Plugins
 projectDesc=Micronaut internal Gradle plugins. Not intended to be used in user's projects
 projectUrl=https://micronaut.io

--- a/src/main/groovy/io/micronaut/build/MavenCentralPublishTask.java
+++ b/src/main/groovy/io/micronaut/build/MavenCentralPublishTask.java
@@ -1,0 +1,140 @@
+package io.micronaut.build;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.UUID;
+
+public abstract class MavenCentralPublishTask extends DefaultTask {
+
+    public enum PublishingType {
+        AUTOMATIC,
+        USER_MANAGED
+    }
+
+    @InputFile
+    public abstract RegularFileProperty getBundle();
+
+    @Input
+    public abstract Property<String> getUsername();
+
+    @Input
+    public abstract Property<String> getPassword();
+
+    @Input
+    @Optional
+    @Option(option = "publishing-type", description = "Configures the Maven Central publishing type.")
+    public abstract Property<PublishingType> getPublishingType();
+
+    public MavenCentralPublishTask() {
+        super();
+        setDescription("Publishes a bundle using Maven Central's Publisher API");
+    }
+
+    private String getBearerToken() {
+        var usernamePassword = String.format("%s:%s", getUsername().get(), getPassword().get());
+        return Base64.getEncoder()
+            .encodeToString(usernamePassword.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @TaskAction
+    public void uploadBundle() throws URISyntaxException, IOException, InterruptedException {
+        var client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(60))
+            .build();
+
+        var file = getBundle().get().getAsFile().toPath();
+        var fileName = file.getFileName().toString();
+        var fileBytes = Files.readAllBytes(file);
+
+        var boundary = UUID.randomUUID().toString();
+
+        var bodyBuilder = "--" + boundary + "\r\n" +
+                          "Content-Disposition: form-data; name=\"bundle\"; filename=\"" + fileName + "\"\r\n" +
+                          "Content-Type: application/octet-stream\r\n\r\n";
+
+        var prefix = bodyBuilder.getBytes(StandardCharsets.UTF_8);
+        var suffix = ("\r\n--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8);
+
+        var requestBody = ByteBuffer.allocate(prefix.length + fileBytes.length + suffix.length)
+            .put(prefix)
+            .put(fileBytes)
+            .put(suffix)
+            .array();
+
+        var uriBuilder = "https://central.sonatype.com/api/v1/publisher/upload?publishingType=" + getPublishingType().getOrElse(PublishingType.USER_MANAGED);
+
+        var request = HttpRequest.newBuilder()
+            .uri(new URI(uriBuilder))
+            .header("Authorization", "Bearer " + getBearerToken())
+            .header("Content-Type", "multipart/form-data; boundary=" + boundary)
+            .POST(HttpRequest.BodyPublishers.ofByteArray(requestBody))
+            .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        getLogger().lifecycle("Upload response: {} {}", response.statusCode(), response.body());
+
+        if (response.statusCode() >= 200 && response.statusCode() < 300) {
+            var deploymentId = response.body();
+            if (deploymentId != null && !deploymentId.isEmpty()) {
+                verifyDeploymentStatus(client, deploymentId);
+            } else {
+                throw new GradleException("Could not extract deploymentId from response: " + response.body());
+            }
+        } else {
+            throw new GradleException("Unexpected status code: " + response.statusCode() + " (" + response.body() + ")");
+        }
+    }
+
+    private void verifyDeploymentStatus(HttpClient client, String deploymentId) throws IOException, InterruptedException {
+        var statusUrl = "https://central.sonatype.com/api/v1/publisher/status?id=" + deploymentId;
+        getLogger().lifecycle("Checking deployment status for {}", deploymentId);
+
+        while (true) {
+            var request = HttpRequest.newBuilder()
+                .uri(URI.create(statusUrl))
+                .header("Authorization", "Bearer " + getBearerToken())
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build();
+
+            var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            getLogger().lifecycle("Status check: {} {}", response.statusCode(), response.body());
+
+            var body = response.body();
+            if (response.statusCode() == 200) {
+                if (body.contains("\"deploymentState\":\"COMPLETE\"")) {
+                    getLogger().lifecycle("Deployment {} completed successfully!", deploymentId);
+                    return;
+                }
+                if (body.contains("\"deploymentState\":\"FAILED\"")) {
+                    throw new GradleException("Deployment " + deploymentId + " failed: " + body);
+                }
+            } else if (response.statusCode() < 200 || response.statusCode() > 300) {
+                getLogger().warn("Status check for deployment " + deploymentId + " failed with: " + body + ". This doesn't necessarily mean that deployment failed, please check status on https://central.sonatype.com/publishing");
+                break;
+            }
+
+            Thread.sleep(10_000);
+        }
+    }
+}

--- a/src/main/groovy/io/micronaut/build/MicronautParentPlugin.java
+++ b/src/main/groovy/io/micronaut/build/MicronautParentPlugin.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * A plugin to be applied on the root project of a multi-project Micronaut project.
+ */
+public class MicronautParentPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project p) {
+        var pluginManager = p.getPluginManager();
+        pluginManager.apply("io.micronaut.build.internal.docs");
+        pluginManager.apply("io.micronaut.build.internal.quality-reporting");
+        pluginManager.apply("io.micronaut.build.internal.parent-pulishing");
+    }
+}

--- a/src/main/groovy/io/micronaut/build/MicronautParentPublishingPlugin.java
+++ b/src/main/groovy/io/micronaut/build/MicronautParentPublishingPlugin.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Delete;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+import org.gradle.api.tasks.bundling.Compression;
+import org.gradle.api.tasks.bundling.Tar;
+
+/**
+ * This plugin should only be applied to the root project, and is responsible
+ * for preparing a bundle for use with the Maven Central Publisher API.
+ */
+public class MicronautParentPublishingPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project p) {
+        var rootProject = p.getRootProject();
+        if (!p.equals(rootProject)) {
+            throw new IllegalStateException("This plugin should only be applied to the root project");
+        }
+        var version = String.valueOf(p.getVersion());
+        if (version.endsWith("-SNAPSHOT")) {
+            // Not supported for SNAPSHOTs
+            return;
+        }
+        var tasks = rootProject.getTasks();
+        var layout = rootProject.getLayout();
+        var buildRepoDirectory = layout.getBuildDirectory().dir("repo");
+        var cleanRepo = tasks.register("cleanRepo", Delete.class, t -> t.delete(buildRepoDirectory));
+        var prepareBundle = registerPrepareBundleTask(tasks, cleanRepo, rootProject, layout, buildRepoDirectory);
+        var providers = rootProject.getProviders();
+        var mavenPublish = tasks.register("publishToMavenCentral", MavenCentralPublishTask.class, task -> {
+            task.getBundle().convention(prepareBundle.flatMap(AbstractArchiveTask::getArchiveFile));
+            task.getUsername().convention(envVarOrSystemProp(providers, "SONATYPE_USERNAME", "sonatypeOssUsername"));
+            task.getPassword().convention(envVarOrSystemProp(providers, "SONATYPE_PASSWORD", "sonatypeOssPassword"));
+            task.getPublishingType().convention(MavenCentralPublishTask.PublishingType.USER_MANAGED);
+        });
+    }
+
+    private static TaskProvider<Tar> registerPrepareBundleTask(TaskContainer tasks, TaskProvider<Delete> cleanRepo, Project rootProject, ProjectLayout layout, Provider<Directory> buildRepoDirectory) {
+        return tasks.register("prepareBundle", Tar.class, config -> {
+            config.dependsOn(cleanRepo);
+            config.mustRunAfter(cleanRepo);
+            config.setCompression(Compression.GZIP);
+            // The way to configure the dependency is super ugly, but we don't have a reliable
+            // method to trigger the publishing from all projects directly.
+            rootProject.getSubprojects().forEach(subproject -> {
+                if (subproject.getTasks().getNames().contains("publishAllPublicationsToBuildRepository")) {
+                    config.dependsOn(subproject.getPath() + ":" + "publishAllPublicationsToBuildRepository");
+                }
+            });
+            config.getDestinationDirectory().convention(layout.getBuildDirectory().dir("maven-bundle"));
+            config.getArchiveBaseName().convention(rootProject.getName() + "-maven-bundle");
+            config.getArchiveVersion().convention(rootProject.provider(() -> String.valueOf(rootProject.getVersion())));
+            config.from(buildRepoDirectory);
+        });
+    }
+
+    public static Provider<String> envVarOrSystemProp(ProviderFactory providers,
+                                                      String envVarName,
+                                                      String systemPropName) {
+        return providers.environmentVariable(envVarName).orElse(providers.systemProperty(systemPropName));
+    }
+}

--- a/src/main/groovy/io/micronaut/docs/asciidoc/AsciiDocEngine.groovy
+++ b/src/main/groovy/io/micronaut/docs/asciidoc/AsciiDocEngine.groovy
@@ -1,11 +1,12 @@
 package io.micronaut.docs.asciidoc
 
-import groovy.transform.InheritConstructors
+
 import io.micronaut.docs.DocEngine
 import org.asciidoctor.Asciidoctor
 import org.asciidoctor.Attributes
 import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
+import org.radeox.api.engine.context.InitialRenderContext
 import org.radeox.api.engine.context.RenderContext
 
 import static org.asciidoctor.Asciidoctor.Factory.create
@@ -15,7 +16,6 @@ import static org.asciidoctor.Asciidoctor.Factory.create
  * @author Graeme Rocher
  * @since 3.2.0
  */
-@InheritConstructors
 class AsciiDocEngine extends DocEngine {
     Asciidoctor asciidoctor = create();
     Map attributes = [
@@ -23,6 +23,11 @@ class AsciiDocEngine extends DocEngine {
         'source-highlighter':'coderay',
         'icons':'font'
     ]
+
+    AsciiDocEngine(InitialRenderContext context) {
+        super(context)
+    }
+
     @Override
     String render(String content, RenderContext context) {
         def optionsBuilder = Options.builder()


### PR DESCRIPTION
This commit introduces a task to publish a release using Maven Central's Publisher API instead of the good old Gradle publish task. The rationale for this change is that since we moved to the new Central publisher, we have builds which sometimes miss artifacts.

The Publisher API makes it possible to publish everything as a unit, making sure that all artifacts are uploaded.

It's worth noting that the Publisher API doesn't support publishing SNAPSHOTs, we have to stay with the legacy publishing tasks for this.

Using this will require a couple changes (despite upgrading the build plugins) :

- the root project must apply the `io.micronaut.build.internal.parent` plugin
- the release workflow need to be updated to use the new task

The first one has to be changed on every project, so the upgrade is not immediate. The second one has to be done on the project template. Note however that upgrading the template will trigger PRs to all projects, which would not have the new plugin in their root project, so it has the potential to break, hence the new minor upgrade.

Publishing from a workflow only requires calling:

    ./gradlew publishToMavenCentral --publishing-type=AUTOMATIC

The AUTOMATIC mode will automatically promote to Maven Central if validation passes. Otherwise, we would use the manual mode, which requires logging in the UI to promote.

Closes #772