### PR TITLE
Add ossIndexAudit to the build plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation libs.gradle.custom.userdata.plugin
     implementation libs.japicmp.plugin
     implementation libs.includegit.plugin
+    implementation libs.sonatype.scan.plugin
 
     implementation libs.tomlj
     implementation libs.maven.model.builder

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ bytebuddy = "1.17.1"
 objenesis = "3.4"
 maven-model-builder = "3.9.9"
 includegit = "0.2.0"
+sonatype-scan = "3.0.0"
 
 [libraries]
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
@@ -43,3 +44,4 @@ typesafe-config = { module = "com.typesafe:config", version.ref = "typesafe-conf
 objenesis = { module = "org.objenesis:objenesis", version.ref = "objenesis" }
 maven-model-builder = { module = "org.apache.maven:maven-model-builder", version.ref = "maven-model-builder" }
 includegit-plugin = { module = "me.champeau.gradle.includegit:plugin", version.ref = "includegit" }
+sonatype-scan-plugin = { module = "org.sonatype.gradle.plugins:scan-gradle-plugin", version.ref = "sonatype-scan" }

--- a/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
@@ -23,6 +23,7 @@ class MicronautBaseModulePlugin implements Plugin<Project> {
         project.pluginManager.apply(MicronautDependencyUpdatesPlugin)
         project.pluginManager.apply(MicronautPublishingPlugin)
         project.pluginManager.apply(MicronautBinaryCompatibilityPlugin)
+        project.pluginManager.apply(SonatypeConfigurationPlugin)
         configureJUnit(project)
         assertSettingsPluginApplied(project)
         project.pluginManager.withPlugin("maven-publish") {

--- a/src/main/groovy/io/micronaut/build/SonatypeConfigurationPlugin.java
+++ b/src/main/groovy/io/micronaut/build/SonatypeConfigurationPlugin.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.sonatype.gradle.plugins.scan.ossindex.OssIndexPluginExtension;
+
+import javax.inject.Inject;
+
+public abstract class SonatypeConfigurationPlugin implements Plugin<Project> {
+
+    @Inject
+    protected abstract ProviderFactory getProviders();
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply("org.sonatype.gradle.plugins.scan");
+        var ossIndexUsername = envVarOrSystemProperty("OSS_INDEX_USERNAME", "ossIndexUsername");
+        var ossIndexPassword = envVarOrSystemProperty("OSS_INDEX_PASSWORD", "ossIndexPassword");
+        if (ossIndexUsername.isPresent() && ossIndexPassword.isPresent()) {
+            var ossIndex = project.getExtensions().getByType(OssIndexPluginExtension.class);
+            ossIndex.setUsername(ossIndexUsername.get());
+            ossIndex.setPassword(ossIndexPassword.get());
+        }
+    }
+
+    private Provider<String> envVarOrSystemProperty(String envVar, String property) {
+        return getProviders().environmentVariable(envVar)
+            .orElse(getProviders().systemProperty(property));
+    }
+}


### PR DESCRIPTION
This will automatically configure the ossIndex audit task to all Micronaut projects. Today this relies on adding manual configuration in each project, which causes errors like the one seen on Micronaut Test Resources, which is not configured. Instead of duplicating code in each project, we should put this in Micronaut Build instead.

The OSS Index plugin itself is far from being Gradle idiomatic, causing unwanted configuration and not using the provider API, but this is a price to pay for now.