### PR TITLE
Allow insecure protocol for external maven publish

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.java
+++ b/src/main/groovy/io/micronaut/build/MicronautPublishingPlugin.java
@@ -120,11 +120,15 @@ public abstract class MicronautPublishingPlugin implements Plugin<Project> {
                     maven.setUrl(externalRepoUri);
                     Provider<String> externalRepoUsername = providers.systemProperty("io.micronaut.publishing.username");
                     Provider<String> externalRepoPassword = providers.systemProperty("io.micronaut.publishing.password");
+                    Provider<String> externalRepoAllowInsecureProtocol = providers.systemProperty("io.micronaut.publishing.allowInsecureProtocol");
                     if (externalRepoUsername.isPresent() && externalRepoPassword.isPresent()) {
                         maven.credentials(credentials -> {
                             credentials.setUsername(externalRepoUsername.get());
                             credentials.setPassword(externalRepoPassword.get());
                         });
+                    }
+                    if (externalRepoAllowInsecureProtocol.isPresent()) {
+                        maven.setAllowInsecureProtocol(Boolean.parseBoolean(externalRepoAllowInsecureProtocol.get()));
                     }
                 });
             }


### PR DESCRIPTION
Hello,

This PR adds the `io.micronaut.publishing.allowInsecureProtocol` property to enable publishing to insecure Maven repositories (HTTP). It was needed in a case where I had to publish a change to an internal repository using an insecure address.

Is there any reason or restriction from the Micronaut team against adding this property?

Thanks.