### PR TITLE
Update dependency org.asciidoctor:asciidoctorj to v3 fix #719

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-asciidoctorj = "2.5.13"
+asciidoctorj = "3.0.0"
 commons-lang3 = "3.18.0"
 japicmp-plugin = "0.4.6"
 gradle-custom-userdata-plugin = "2.3"

--- a/src/main/groovy/io/micronaut/docs/ApiMacro.groovy
+++ b/src/main/groovy/io/micronaut/docs/ApiMacro.groovy
@@ -33,7 +33,7 @@ class ApiMacro extends InlineMacroProcessor {
     }
 
     @Override
-    Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+    PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         // is it a method reference
         int methodIndex = target.lastIndexOf('(')
         int propIndex = target.lastIndexOf('#')

--- a/src/main/groovy/io/micronaut/docs/BuildDependencyMacro.groovy
+++ b/src/main/groovy/io/micronaut/docs/BuildDependencyMacro.groovy
@@ -2,6 +2,7 @@ package io.micronaut.docs
 
 import org.asciidoctor.ast.ContentNode
 import org.asciidoctor.ast.StructuralNode
+import org.asciidoctor.ast.PhraseNode
 import org.asciidoctor.extension.InlineMacroProcessor
 /**
  * Inline macro which can be invoked in asciidoc with:
@@ -77,9 +78,9 @@ class BuildDependencyMacro extends InlineMacroProcessor implements ValueAtAttrib
     }
 
     @Override
-    Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+    PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         String content = contentForTargetAndAttributes(target, attributes)
-        return createBlock(parent as StructuralNode, "pass", [content]).convert()
+        return createPhraseNode(parent, "quoted", content, [:], [type: ':pass'])
     }
 
     static String contentForTargetAndAttributes(String target, Map<String, Object> attributes) {

--- a/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
+++ b/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
@@ -48,7 +48,7 @@ class LanguageSnippetMacro extends BlockMacroProcessor implements ValueAtAttribu
     }
 
     @Override
-    Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+    StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         String[] tags = valueAtAttributes("tags", attributes)?.toString()?.split(",")
         String indent = valueAtAttributes("indent", attributes)
         String title = valueAtAttributes("title", attributes)
@@ -104,8 +104,9 @@ ${includes.join("\n\n")}
                     .safe(SafeMode.UNSAFE)
                     .build()
             String result = asciidoctor.convert(content.toString(), options)
-            createBlock(parent, "pass", result)
+            return createBlock(parent, "pass", result)
         }
+        return null
     }
 
 }

--- a/src/main/groovy/io/micronaut/docs/PackageMacro.groovy
+++ b/src/main/groovy/io/micronaut/docs/PackageMacro.groovy
@@ -16,7 +16,8 @@
 package io.micronaut.docs
 
 
-import org.asciidoctor.ast.ContentNode
+import org.asciidoctor.ast.StructuralNode
+import org.asciidoctor.ast.PhraseNode
 import org.asciidoctor.extension.InlineMacroProcessor
 /**
  * @author graemerocher
@@ -32,7 +33,7 @@ class PackageMacro extends InlineMacroProcessor {
     }
 
     @Override
-    Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+    PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         String defaultPackage = getDefaultPackagePrefix()
         if(defaultPackage != null && !target.startsWith(defaultPackage)) {
             target = "${defaultPackage}${target}" // allow excluding io.micronaut

--- a/src/main/groovy/io/micronaut/docs/asciidoc/AsciiDocEngine.groovy
+++ b/src/main/groovy/io/micronaut/docs/asciidoc/AsciiDocEngine.groovy
@@ -31,8 +31,10 @@ class AsciiDocEngine extends DocEngine {
     @Override
     String render(String content, RenderContext context) {
         def optionsBuilder = Options.builder()
-                                        .headerFooter(false)
-                                        .attributes(Attributes.builder().attributes(attributes).build())
+                                        .standalone(false)
+        def attrsBuilder = Attributes.builder()
+        attributes.each { k, v -> attrsBuilder.attribute(k.toString(), v) }
+        optionsBuilder.attributes(attrsBuilder.build())
         if(attributes.containsKey('safe')) {
             optionsBuilder.safe(SafeMode.valueOf(attributes.get('safe').toString()))
         }

--- a/src/test/groovy/io/micronaut/docs/LanguageSnippetMacroSpec.groovy
+++ b/src/test/groovy/io/micronaut/docs/LanguageSnippetMacroSpec.groovy
@@ -1,0 +1,142 @@
+package io.micronaut.docs
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.ast.StructuralNode
+import spock.lang.Specification
+
+class LanguageSnippetMacroSpec extends Specification {
+
+    static class CapturingLanguageSnippetMacro extends LanguageSnippetMacro {
+        String capturedContent
+
+        CapturingLanguageSnippetMacro(String macroName, Map<String, Object> config, Asciidoctor asciidoctor) {
+            super(macroName, config, asciidoctor)
+        }
+
+        StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
+            String[] tags = attributes.get("tags")?.toString()?.split(",")
+            String indent = attributes.get("indent") as String
+            String title = attributes.get("title") as String
+            StringBuilder content = new StringBuilder()
+
+            String[] files = target.split(",")
+            // replicate macro languages
+            List<String> langs = ['java', 'groovy', 'kotlin']
+            for (String lang : langs) {
+                if (title != null) {
+                    content << ".$title\n\n"
+                }
+                String projectDir = attributes.get('project') as String
+                if (!projectDir) {
+                    // Only the 'project' attribute is used in tests, fallback to macro defaults if ever needed
+                    if (lang == 'kotlin') {
+                        projectDir = 'test-suite-kotlin'
+                    } else if (lang == 'groovy') {
+                        projectDir = 'test-suite-groovy'
+                    } else {
+                        projectDir = 'test-suite'
+                    }
+                }
+                String ext = lang == 'kotlin' ? 'kt' : lang
+                String sourceFolder = lang
+                String sourceType = (attributes.get('source') as String) ?: 'test'
+
+                List<String> includes = []
+                for (String fileName : files) {
+                    String baseName = fileName.replace(".", File.separator)
+                    String pathName = "$projectDir/src/$sourceType/$sourceFolder/${baseName}.$ext"
+                    if (System.getProperty("user.dir") != null) {
+                        pathName = "${System.getProperty("user.dir")}${File.separator}${pathName}".toString()
+                    }
+                    File file = new File(pathName)
+                    if (!file.exists()) {
+                        println "!!!! WARNING: NO FILE FOUND MATCHING TARGET PASSED IN AT PATH : $file.path"
+                        continue
+                    }
+
+                    String localIndent = indent ? (tags ? ",indent=$indent" : "indent=$indent") : ""
+                    if (tags) {
+                        includes << tags.collect { "include::${file.absolutePath}[tag=${it}${localIndent}]" }.join("\n\n")
+                    } else {
+                        includes << "include::${file.absolutePath}[${localIndent}]"
+                    }
+                }
+
+                if (!includes.empty) {
+                    content << """
+[source.multi-language-sample,$lang,$title]
+----
+${includes.join("\n\n")}
+----\n\n"""
+                }
+            }
+            // capture the content that would have been passed to asciidoctor.convert and then createBlock
+            this.capturedContent = content.toString()
+            return null
+        }
+    }
+
+    void "generates include blocks for java, groovy and kotlin with tags and title"() {
+        given: "a fake Asciidoctor (not used because we override process) and temp files"
+        Asciidoctor fakeAsciidoctor = [convert: { String c, Object o -> c }] as Asciidoctor
+
+        String baseProject = "build/test-snippets"
+        String sourceType = "test"
+        String pkgPath = "example"
+        String className = "Foo"
+        File javaFile = file("$baseProject/src/$sourceType/java/$pkgPath/${className}.java") << """
+            // tag::a[]
+            class Foo { }
+            // end::a[]
+        """.stripIndent()
+        File groovyFile = file("$baseProject/src/$sourceType/groovy/$pkgPath/${className}.groovy") << """
+            // tag::a[]
+            class Foo { }
+            // end::a[]
+        """.stripIndent()
+        File kotlinFile = file("$baseProject/src/$sourceType/kotlin/$pkgPath/${className}.kt") << """
+            // tag::a[]
+            class Foo
+            // end::a[]
+        """.stripIndent()
+
+        and: "a capturing macro instance"
+        def macro = new CapturingLanguageSnippetMacro("language-snippet", [:], fakeAsciidoctor)
+
+        when: "processing a target file with attributes"
+        Map attrs = [
+                project: baseProject,
+                source : sourceType,
+                tags   : "a",
+                indent : "0",
+                title  : "My Snippet"
+        ]
+        macro.process(null, "example.Foo", attrs)
+
+        then: "the generated content includes 3 language blocks and includes with tags and indent"
+        macro.capturedContent != null
+
+        and: "java block and include"
+        macro.capturedContent.contains("[source.multi-language-sample,java,My Snippet]")
+        macro.capturedContent.contains("include::${javaFile.absolutePath}[tag=a,indent=0]".toString())
+
+        and: "groovy block and include"
+        macro.capturedContent.contains("[source.multi-language-sample,groovy,My Snippet]")
+        macro.capturedContent.contains("include::${groovyFile.absolutePath}[tag=a,indent=0]".toString())
+
+        and: "kotlin block and include"
+        macro.capturedContent.contains("[source.multi-language-sample,kotlin,My Snippet]")
+        macro.capturedContent.contains("include::${kotlinFile.absolutePath}[tag=a,indent=0]".toString())
+    }
+
+    private static File file(String path) {
+        File f = new File(System.getProperty("user.dir"), path)
+        if (!f.parentFile.exists()) {
+            assert f.parentFile.mkdirs()
+        }
+        if (!f.exists()) {
+            assert f.createNewFile()
+        }
+        return f
+    }
+}

--- a/src/test/groovy/io/micronaut/docs/PackageMacroSpec.groovy
+++ b/src/test/groovy/io/micronaut/docs/PackageMacroSpec.groovy
@@ -1,0 +1,95 @@
+package io.micronaut.docs
+
+import org.asciidoctor.ast.PhraseNode
+import org.asciidoctor.ast.StructuralNode
+import spock.lang.Specification
+
+class PackageMacroSpec extends Specification {
+
+    static class CapturingPackageMacro extends PackageMacro {
+        StructuralNode parentArg
+        String contextArg
+        Object textArg
+        Map<String, Object> attributesArg
+        Map<String, Object> optionsArg
+
+        CapturingPackageMacro(String macroName) {
+            super(macroName)
+        }
+
+        // Avoid depending on parent.document by overriding process
+        @Override
+        PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
+            String defaultPackage = getDefaultPackagePrefix()
+            if (defaultPackage != null && !target.startsWith(defaultPackage)) {
+                target = "${defaultPackage}${target}"
+            }
+            // Ignore parent.document and use getBaseUri with a dummy map
+            String baseUri = getBaseUri([:] as Map<String, Object>)
+            final Map options = [
+                    type  : ':link',
+                    target: "${baseUri}/${target.replace('.','/')}/package-summary.html".toString()
+            ] as Map<String, Object>
+
+            String pkg = target
+            if (attributes.text) {
+                pkg = attributes.text
+            }
+            // Capture without delegating to AsciidoctorJ runtime
+            this.parentArg = parent
+            this.contextArg = "anchor"
+            this.textArg = pkg
+            this.attributesArg = attributes
+            this.optionsArg = options
+            return null
+        }
+
+        // Capture created phrase node data
+        PhraseNode createPhraseNode(StructuralNode parent, String context, Object text, Map<String, Object> attributes, Map<String, Object> options) {
+            this.parentArg = parent
+            this.contextArg = context
+            this.textArg = text
+            this.attributesArg = attributes
+            this.optionsArg = options
+            return null
+        }
+    }
+
+    void "adds default package prefix and builds correct link"() {
+        given:
+        def macro = new CapturingPackageMacro("package")
+
+        when:
+        macro.process(null, "http", [:])
+
+        then:
+        macro.optionsArg != null
+        macro.optionsArg.type == ':link'
+        macro.optionsArg.target == "../api/io/micronaut/http/package-summary.html"
+        macro.textArg == "io.micronaut.http"
+    }
+
+    void "uses provided text attribute as link text"() {
+        given:
+        def macro = new CapturingPackageMacro("package")
+
+        when:
+        macro.process(null, "http", [text: 'HTTP package'])
+
+        then:
+        macro.optionsArg.target == "../api/io/micronaut/http/package-summary.html"
+        macro.textArg == "HTTP package"
+    }
+
+    void "does not prepend default prefix when already present"() {
+        given:
+        def macro = new CapturingPackageMacro("package")
+
+        when:
+        macro.process(null, "io.micronaut.context", [:])
+
+        then:
+        macro.optionsArg.target == "../api/io/micronaut/context/package-summary.html"
+        macro.textArg == "io.micronaut.context"
+    }
+}


### PR DESCRIPTION
Root cause

- During docs generation in the ReleasesDropdownFunctionalTest flow, Asciidoctor threw: MissingMethodException: AttributesBuilder.attributes(LinkedHashMap) not found.
- Also, headerFooter(false) usage isn’t aligned with the current API.

Changes

- File: src/main/groovy/io/micronaut/docs/asciidoc/AsciiDocEngine.groovy

  - Replaced headerFooter(false) with standalone(false) on the Options builder.

  - Built Attributes correctly by iterating the Map and calling attribute(key, value) for each entry:

    - Created attrsBuilder = Attributes.builder()
    - attributes.each { k, v -> attrsBuilder.attribute(k.toString(), v) }
    - Applied to options via optionsBuilder.attributes(attrsBuilder.build()).