### PR TITLE
Use Java 21 by default

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
     - name: "🔧 Setup Gradle"
       uses: gradle/actions/setup-gradle@v4
     - name: Check plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           ref: ${{ github.head_ref }}
       - name: Set the current release version
         id: release_version

--- a/build.gradle
+++ b/build.gradle
@@ -215,8 +215,8 @@ gradlePlugin {
 java {
     withJavadocJar()
     withSourcesJar()
-    sourceCompatibility = 17
-    targetCompatibility = 17
+    sourceCompatibility = 21
+    targetCompatibility = 21
 }
 
 def ossUser = System.getenv("SONATYPE_USERNAME") ?: project.hasProperty("sonatypeOssUsername") ? project.sonatypeOssUsername : ''

--- a/src/functionalTest/gradle-projects/test-aot-module/build.gradle
+++ b/src/functionalTest/gradle-projects/test-aot-module/build.gradle
@@ -10,6 +10,6 @@ repositories {
 
 micronautBuild {
 	aot {
-		version = "1.0.0-M2"
+		version = "2.9.0"
 	}
 }

--- a/src/functionalTest/gradle-projects/test-aot-module/gradle.properties
+++ b/src/functionalTest/gradle-projects/test-aot-module/gradle.properties
@@ -1,9 +1,4 @@
 projectVersion=1.0.0-SNAPSHOT
-micronautDocsVersion=2.0.0.RC1
-micronautVersion=3.2.0
-micronautTestVersion=2.3.7
-groovyVersion=3.0.8
-spockVersion=2.0-groovy-3.0
 
 title=Micronaut AOT test module
 projectDesc=Build time optimizations for Micronaut
@@ -12,10 +7,9 @@ githubSlug=micronaut-projects/micronaut-aot-test-module
 developers=Graeme Rocher
 
 # Micronaut core branch for BOM pull requests
-githubCoreBranch=3.2.x
+githubCoreBranch=4.9.x
 
 bomProperty=micronautAotVersion
 
 org.gradle.caching=true
 org.gradle.parallel=true
-

--- a/src/functionalTest/gradle-projects/test-aot-module/gradle/libs.versions.toml
+++ b/src/functionalTest/gradle-projects/test-aot-module/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+micronaut = "4.9.10"
+micronaut-platform = "4.9.3"
+micronaut-docs = "2.0.0"
+micronaut-test = "4.8.1"
+groovy = "4.0.27"
+spock = "2.3-groovy-4.0"

--- a/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
+++ b/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
@@ -2,7 +2,7 @@ package io.micronaut.build
 
 class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
 
-    void "defaults to Java 17"() {
+    void "defaults to Java 21"() {
         given:
         withSample("test-micronaut-module")
 
@@ -19,7 +19,7 @@ class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
         run 'printJavaVersion'
 
         then:
-        outputContains "Java version: 17"
+        outputContains "Java version: 21"
     }
 
     void "test java defaults to current JDK"() {

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -99,6 +99,7 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
             dependencies.addProvider("testRuntimeOnly", logbackVersionProvider.map {
                 optionalDependency("ch.qos.logback:logback-classic", it)
             })
+            dependencies.add("testRuntimeOnly", "org.junit.platform:junit-platform-launcher")
         }
 
         project.tasks.withType(Groovydoc).configureEach {

--- a/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
@@ -126,7 +126,7 @@ abstract class MicronautDocsPlugin implements Plugin<Project> {
                         'sourceDir': rootProject.projectDir.absolutePath,
                         'sourcedir': rootProject.projectDir.absolutePath,
                         'includedir': "${processConfigPropsOutputDir.get().asFile.parentFile}/",
-                        'javaee': 'https://docs.oracle.com/en/java/javase/17/docs/api/',
+                        'javaee': 'https://docs.oracle.com/en/java/javase/21/docs/api/',
                         'javase': 'https://jakarta.ee/specifications/platform/9/apidocs',
                         'groovyapi': 'http://docs.groovy-lang.org/latest/html/gapi/',
                         'grailsapi': 'http://docs.grails.org/latest/api/',

--- a/src/main/groovy/io/micronaut/docs/Jdk.groovy
+++ b/src/main/groovy/io/micronaut/docs/Jdk.groovy
@@ -4,7 +4,7 @@ import groovy.transform.CompileStatic
 
 @CompileStatic
 class Jdk implements JvmLibrary {
-    private static final String DEFAULT_URI = "https://docs.oracle.com/en/java/javase/17/docs/api"
+    private static final String DEFAULT_URI = "https://docs.oracle.com/en/java/javase/21/docs/api"
 
     @Override
     String defaultUri() {

--- a/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -15,8 +15,8 @@ import javax.inject.Inject;
 public abstract class MicronautBuildExtension {
 
   public static final String DEFAULT_DEPENDENCY_UPDATES_PATTERN = "(?i).+(-|\\.?)(b|M|RC|Dev)\\d?.*";
-  public static final int DEFAULT_JAVA_VERSION = 17;
-  public static final String DEFAULT_CHECKSTYLE_VERSION = "10.5.0";
+  public static final int DEFAULT_JAVA_VERSION = 21;
+  public static final String DEFAULT_CHECKSTYLE_VERSION = "11.0.1";
 
   private final BuildEnvironment environment;
 

--- a/src/test/groovy/io/micronaut/docs/JdkApiMacroSpec.groovy
+++ b/src/test/groovy/io/micronaut/docs/JdkApiMacroSpec.groovy
@@ -6,7 +6,7 @@ class JdkApiMacroSpec extends AbstractConverterSpec {
         convert "jdk:java.util.concurrent.CompletableFuture[]"
 
         then:
-        converted.contains '<a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/CompletableFuture.html">CompletableFuture</a>'
+        converted.contains '<a href="https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/CompletableFuture.html">CompletableFuture</a>'
     }
 
     def "can specify a module explicitly"() {
@@ -14,6 +14,6 @@ class JdkApiMacroSpec extends AbstractConverterSpec {
         convert "jdk:java.util.logging.ConsoleHandler[module=java.logging]"
 
         then:
-        converted.contains '<a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.logging/java/util/logging/ConsoleHandler.html">ConsoleHandler</a>'
+        converted.contains '<a href="https://docs.oracle.com/en/java/javase/21/docs/api/java.logging/java/util/logging/ConsoleHandler.html">ConsoleHandler</a>'
     }
 }


### PR DESCRIPTION
This commit upgrades Micronaut Build so that modules compile with Java 21 by default. It also upgrades Micronaut Build itself to use Java 21.