### PR TITLE
Introduce JSpecify

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ configurations {
 
 tasks.withType(Test).configureEach {
     useJUnitPlatform()
+    systemProperty("jspecify.version", libs.versions.jspecify.get())
 }
 
 tasks.register('functionalTest', Test) {
@@ -132,6 +133,9 @@ tasks.named('jar', Jar) {
 def generateVersions = tasks.register("generateVersions", VersionsWriterTask) {
     versions.put("bytebuddy", libs.versions.bytebuddy)
     versions.put("objenesis", libs.versions.objenesis)
+    versions.put("checkstyle", libs.versions.checkstyle)
+    versions.put("jspecify", libs.versions.jspecify)
+    versions.put("errorprone", libs.versions.errorprone)
     className = "io.micronaut.build.utils.DefaultVersions"
     outputDirectory = layout.buildDirectory.dir("generated/versions")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ objenesis = "3.4"
 maven-model-builder = "3.9.11"
 includegit = "0.3.0"
 sonatype-scan = "3.0.0"
-errorprone = "4.3.0"
+errorprone = "2.41.0"
 jspecify = "1.0.0"
 checkstyle = "11.0.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,9 @@ objenesis = "3.4"
 maven-model-builder = "3.9.11"
 includegit = "0.3.0"
 sonatype-scan = "3.0.0"
-errorprone="4.3.0"
+errorprone = "4.3.0"
+jspecify = "1.0.0"
+checkstyle = "11.0.1"
 
 [libraries]
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
@@ -46,3 +48,8 @@ objenesis = { module = "org.objenesis:objenesis", version.ref = "objenesis" }
 maven-model-builder = { module = "org.apache.maven:maven-model-builder", version.ref = "maven-model-builder" }
 includegit-plugin = { module = "me.champeau.gradle.includegit:plugin", version.ref = "includegit" }
 sonatype-scan-plugin = { module = "org.sonatype.gradle.plugins:scan-gradle-plugin", version.ref = "sonatype-scan" }
+
+# For automated dependency updates
+checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }
+errorprone = { module = "com.google.errorprone:error_prone_core", version.ref = "errorprone" }
+jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }

--- a/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
+++ b/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
@@ -92,4 +92,35 @@ You can do this directly in the project, or, better, in a convention plugin if i
             succeeded ':subproject2:compileTestJava' // overrides to JUnit5
         }
     }
+
+    def "adds JSpecify dependency by default"() {
+        withSample("test-micronaut-module")
+
+        when:
+        run 'subproject1:dependencies', '--configuration', configuration
+
+        then:
+        outputContains "org.jspecify:jspecify:${System.getProperty("jspecify.version")}"
+
+        where:
+        configuration << ["compileOnly", "testCompileOnly"]
+    }
+
+    def "can disable JSpecify addition"() {
+        withSample("test-micronaut-module")
+        file("subproject1/build.gradle") << """
+        micronautBuild {
+            useJSpecify = false
+        }
+        """
+
+        when:
+        run 'subproject1:dependencies', '--configuration', configuration
+
+        then:
+        outputDoesNotContain "org.jspecify:jspecify:${System.getProperty("jspecify.version")}"
+
+        where:
+        configuration << ["compileOnly", "testCompileOnly"]
+    }
 }

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -48,6 +48,7 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
         def byteBuddyVersionProvider = versionProviderOrDefault(project, 'bytebuddy', List.of("libs", "mnTest"), DefaultVersions.BYTEBUDDY_VERSION)
         def objenesisVersionProvider = versionProviderOrDefault(project, 'objenesis', List.of("libs", "mnTest"), DefaultVersions.OBJENESIS_VERSION)
         def logbackVersionProvider = versionProviderOrDefault(project, 'logback', List.of("libs", "mnLogging"), '')
+        def jspecifyVersionProvider = versionProviderOrDefault(project, 'jspecify', List.of("libs"), DefaultVersions.JSPECIFY_VERSION)
 
         project.configurations {
             documentation
@@ -100,6 +101,18 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
                 optionalDependency("ch.qos.logback:logback-classic", it)
             })
             dependencies.add("testRuntimeOnly", "org.junit.platform:junit-platform-launcher")
+            project.configurations.compileOnly.dependencies.addAllLater(micronautBuild.useJSpecify.zip(jspecifyVersionProvider) { enabled, version ->
+                if (Boolean.TRUE == enabled) {
+                    return [dependencies.create("org.jspecify:jspecify:$version")]
+                }
+                return []
+            })
+            project.configurations.testCompileOnly.dependencies.addAllLater(micronautBuild.useJSpecify.zip(jspecifyVersionProvider) { enabled, version ->
+                if (Boolean.TRUE == enabled) {
+                    return [dependencies.create("org.jspecify:jspecify:$version")]
+                }
+                return []
+            })
         }
 
         project.tasks.withType(Groovydoc).configureEach {

--- a/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -3,6 +3,7 @@ package io.micronaut.build;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import io.micronaut.build.pom.BomSuppressions;
+import io.micronaut.build.utils.DefaultVersions;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.artifacts.ResolutionStrategy;
@@ -16,7 +17,8 @@ public abstract class MicronautBuildExtension {
 
   public static final String DEFAULT_DEPENDENCY_UPDATES_PATTERN = "(?i).+(-|\\.?)(b|M|RC|Dev)\\d?.*";
   public static final int DEFAULT_JAVA_VERSION = 21;
-  public static final String DEFAULT_CHECKSTYLE_VERSION = "11.0.1";
+  @Deprecated
+  public static final String DEFAULT_CHECKSTYLE_VERSION = DefaultVersions.CHECKSTYLE_VERSION;
 
   private final BuildEnvironment environment;
 
@@ -34,7 +36,7 @@ public abstract class MicronautBuildExtension {
 
     getJavaVersion().convention(DEFAULT_JAVA_VERSION);
     getTestJavaVersion().convention(Integer.valueOf(JavaVersion.current().getMajorVersion()));
-    getCheckstyleVersion().convention(DEFAULT_CHECKSTYLE_VERSION);
+    getCheckstyleVersion().convention(DefaultVersions.CHECKSTYLE_VERSION);
     getDependencyUpdatesPattern().convention(DEFAULT_DEPENDENCY_UPDATES_PATTERN);
     getEnforcedPlatform().convention(false);
     getEnableProcessing().convention(false);
@@ -84,6 +86,12 @@ public abstract class MicronautBuildExtension {
    * The checkstyle version
    */
   public abstract Property<String> getCheckstyleVersion();
+
+    /**
+     * If set to true, then JSpecify will automatically be added to the compile classpath.
+     * @return the JSpecify property
+     */
+  public abstract Property<Boolean> getUseJSpecify();
 
   /**
    * The default dependency update pattern

--- a/src/main/java/io/micronaut/build/MicronautBuildExtensionPlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildExtensionPlugin.java
@@ -32,5 +32,6 @@ public abstract class MicronautBuildExtensionPlugin implements Plugin<Project> {
         BuildEnvironment buildEnvironment = new BuildEnvironment(project.getProviders());
         var micronautBuild = project.getExtensions().create("micronautBuild", MicronautBuildExtension.class, buildEnvironment);
         micronautBuild.getTestFramework().convention(TestFramework.SPOCK);
+        micronautBuild.getUseJSpecify().convention(true);
     }
 }


### PR DESCRIPTION
This commit will automatically inject a dependency on JSpecify to all Micronaut modules. This dependency is compile only.

A flag on the `micronautBuild` extension lets users disable the addition of the dependency if needed.