### PR TITLE
fix(japicmp): disambiguate detached configurations with Bundling.EXTERNAL

### DIFF
--- a/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
+++ b/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java
@@ -25,6 +25,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.Bundling;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.catalog.internal.TomlFileGenerator;
@@ -148,7 +149,14 @@ public class MicronautBinaryCompatibilityPlugin implements Plugin<Project> {
         project.getRepositories().forEach(r ->
             detachedResolver.getRepositories().add(r)
         );
-        return detachedResolver.getConfigurations().detachedConfiguration();
+        Configuration configuration = detachedResolver.getConfigurations().detachedConfiguration();
+        configuration.setCanBeConsumed(false);
+        configuration.setCanBeResolved(true);
+        configuration.getAttributes().attribute(
+                Bundling.BUNDLING_ATTRIBUTE,
+                project.getObjects().named(Bundling.class, Bundling.EXTERNAL)
+        );
+        return configuration;
     }
 
     private static String findGroupOf(Project project) {


### PR DESCRIPTION
MicronautBinaryCompatibilityPlugin created detached configurations for the japiCmp baseline resolution without specifying the dependency bundling attribute. This caused Gradle to fail variant selection for artifacts like org.jetbrains.kotlinx:kotlinx-coroutines-debug which publish both external (runtimeElements) and shadowed (shadowRuntimeElements) variants.

**Changes:**

- io.micronaut.build.compat.MicronautBinaryCompatibilityPlugin
- In createDetachedConfigurationWithWorkaroundGradleResolutionError(Project):
- Set configuration to be resolvable and not consumable.
- Explicitly set org.gradle.dependency.bundling = external via Bundling.BUNDLING_ATTRIBUTE to select the normal runtimeElements variant.

**Rationale:**
Avoids “Cannot choose between the available variants … only attribute distinguishing these variants is 'org.gradle.dependency.bundling'” errors when resolving baseline artifacts for japiCmp in composite builds (e.g. micronaut-test with Micronaut core BOM -> kotlinx-coroutines-bom 1.8.1).

**Impact:**
japiCmp no longer fails due to variant ambiguity when resolving baseline classpath/jar artifacts in Gradle 9 builds.
Keeps comparison against the standard external artifacts (as consumed by downstream users). If needed, this could be made configurable to use shadowed artifacts.