### PR TITLE
Remove toolchains

### DIFF
--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -121,8 +121,13 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
         def javaPluginExtension = project.extensions.findByType(JavaPluginExtension)
         JavaToolchainService toolchains = project.getExtensions().getByType(JavaToolchainService.class);
 
-        javaPluginExtension.toolchain.languageVersion.convention(micronautBuildExtension.javaVersion.map(JavaLanguageVersion::of))
         project.afterEvaluate {
+            if (micronautBuildExtension.getUseToolchains().getOrElse(false)) {
+                javaPluginExtension.toolchain.languageVersion.convention(micronautBuildExtension.javaVersion.map(JavaLanguageVersion::of))
+            } else {
+                javaPluginExtension.sourceCompatibility = micronautBuildExtension.javaVersion.map(JavaLanguageVersion::of).get()
+                javaPluginExtension.targetCompatibility = micronautBuildExtension.javaVersion.map(JavaLanguageVersion::of).get()
+            }
             if (micronautBuildExtension.sourceCompatibility.isPresent() || micronautBuildExtension.targetCompatibility.isPresent()) {
                 project.logger.warn """
 The "sourceCompatibility" and "targetCompatibility" properties are deprecated.
@@ -166,9 +171,15 @@ You can do this directly in the project, or, better, in a convention plugin if i
                     enabled = false
                 }
             }
-            javaLauncher.set(toolchains.launcherFor {
-                languageVersion.set(micronautBuildExtension.testJavaVersion.map { JavaLanguageVersion.of(it) })
-            })
+        }
+        project.afterEvaluate { unused ->
+            project.tasks.withType(Test).configureEach {
+                if (micronautBuildExtension.getUseToolchains().getOrElse(false)) {
+                    javaLauncher.set(toolchains.launcherFor {
+                        languageVersion.set(micronautBuildExtension.testJavaVersion.map { JavaLanguageVersion.of(it) })
+                    })
+                }
+            }
         }
 
         project.tasks.withType(GroovyCompile).configureEach {

--- a/src/main/groovy/io/micronaut/build/docs/JavadocAggregatorPlugin.java
+++ b/src/main/groovy/io/micronaut/build/docs/JavadocAggregatorPlugin.java
@@ -69,7 +69,7 @@ public abstract class JavadocAggregatorPlugin implements Plugin<Project> {
             });
         });
         JavaToolchainService toolchains = project.getExtensions().getByType(JavaToolchainService.class);
-        project.getTasks().register("javadoc", Javadoc.class, javadoc -> {
+        var javadocProvider = project.getTasks().register("javadoc", Javadoc.class, javadoc -> {
             javadoc.setDescription("Generate javadocs from all child projects as if it was a single project");
             javadoc.setGroup("Documentation");
 
@@ -78,8 +78,6 @@ public abstract class JavadocAggregatorPlugin implements Plugin<Project> {
             StandardJavadocDocletOptions options = (StandardJavadocDocletOptions) javadoc.getOptions();
             options.author(true);
             javadoc.exclude("example/**");
-            // Use Java Toolchain to render consistent javadocs
-            javadoc.getJavadocTool().convention(toolchains.javadocToolFor(spec -> spec.getLanguageVersion().set(micronautBuildExtension.getJavaVersion().map(JavaLanguageVersion::of))));
             if (micronautBuildExtension.getSourceCompatibility().isPresent()) {
                 options.setSource(micronautBuildExtension.getSourceCompatibility().get());
             } else {
@@ -105,6 +103,12 @@ public abstract class JavadocAggregatorPlugin implements Plugin<Project> {
             options.addBooleanOption("notimestamp", true);
             javadoc.setSource(javadocAggregator);
             javadoc.setClasspath(javadocAggregatorClasspath);
+        });
+        project.afterEvaluate(unused -> {
+            if (micronautBuildExtension.getUseToolchains().getOrElse(false)) {
+                javadocProvider.configure(javadoc -> // Use Java Toolchain to render consistent javadocs
+                    javadoc.getJavadocTool().convention(toolchains.javadocToolFor(spec -> spec.getLanguageVersion().set(micronautBuildExtension.getJavaVersion().map(JavaLanguageVersion::of)))));
+            }
         });
     }
 

--- a/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -116,6 +116,8 @@ public abstract class MicronautBuildExtension {
    */
   public abstract Property<TestFramework> getTestFramework();
 
+  public abstract Property<Boolean> getUseToolchains();
+
   void bomSuppressions(Action<? super BomSuppressions> spec) {
     spec.execute(getBomSuppressions());
   }

--- a/src/main/java/io/micronaut/build/MicronautBuildExtensionPlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildExtensionPlugin.java
@@ -32,5 +32,13 @@ public abstract class MicronautBuildExtensionPlugin implements Plugin<Project> {
         BuildEnvironment buildEnvironment = new BuildEnvironment(project.getProviders());
         var micronautBuild = project.getExtensions().create("micronautBuild", MicronautBuildExtension.class, buildEnvironment);
         micronautBuild.getTestFramework().convention(TestFramework.SPOCK);
+        micronautBuild.getUseToolchains().convention(
+            project.getProviders().environmentVariable("USE_GRADLE_TOOLCHAINS").map(use -> {
+                if (use.trim().isEmpty()) {
+                    return true;
+                }
+                return Boolean.parseBoolean(use);
+            }).orElse(false)
+        );
     }
 }


### PR DESCRIPTION
This commit is a follow-up to https://github.com/micronaut-projects/micronaut-project-template/pull/608. By removing the system JDKs, we're highlighting another problem with our builds. When we want to test with Java 21, we were (rightfully) trying to compile sources with Java 17, which isn't available anymore. So this commit removes the use of Gradle's toolchains by default, and replaces it with the good old "source/target" compatibility.

A flag is still available in case a particular project wants to override this. This change will make it so that now we'll be able to compile a project with Java 17, while there's no Java 17 JDK on the machine.

However, this reintroduces a problem that we won't be able to test future Java versions which are not supported by Gradle.

There's no ideal solution for this problem:

- if we use toolchains, then it means that we have to install multiple JDKs on the machine: one to run Gradle, one to build the project with the expected Java version (e.g 17) and one to run the tests (e.g Java 21). However, our build plugins do NOT make the difference between the version used for compilation and the one used for tests. In addition, some projects use the public Micronaut Gradle plugin as a dependency, in which case the test resources service is started using the default machine JDK, which causes other errors
- if we don't use toolchains (this commit), then we fix the inconsistencies between several versions of Java of a project, we simplify the setup (single Java version on the machine) BUT we're stuck to whatever Gradle supports

As a workaround for the 2d issue, this commit configures the `useToolchains` flag so that if an environment variable is set, then toolchains will be used, which will give us the opportunity to test future releases of the JDK by installing 2 versions in a workflow. However, this may still lead to inconsistencies between the version used for compilation and for tests, depending on the project setup.

If merged this would have to be backported to 8.0.x.