### PR TITLE
Remove some automatic dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,8 +135,6 @@ tasks.named('jar', Jar) {
 }
 
 def generateVersions = tasks.register("generateVersions", VersionsWriterTask) {
-    versions.put("bytebuddy", libs.versions.bytebuddy)
-    versions.put("objenesis", libs.versions.objenesis)
     className = "io.micronaut.build.utils.DefaultVersions"
     outputDirectory = layout.buildDirectory.dir("generated/versions")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,8 +15,6 @@ spotless-plugin = "7.2.1"
 testlogger-plugin = "4.0.0"
 tomlj = "1.1.1"
 typesafe-config = "1.4.5"
-bytebuddy = "1.17.7"
-objenesis = "3.4"
 maven-model-builder = "3.9.11"
 includegit = "0.3.0"
 sonatype-scan = "3.0.0"
@@ -25,7 +23,6 @@ bouncycastle="1.82"
 
 [libraries]
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
-bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 japicmp-plugin = { module = "me.champeau.gradle:japicmp-gradle-plugin", version.ref = "japicmp-plugin" }
 gradle-custom-userdata-plugin = { module = "com.gradle:common-custom-user-data-gradle-plugin", version.ref = "gradle-custom-userdata-plugin" }
@@ -43,7 +40,6 @@ spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", ver
 testlogger-plugin = { module = "com.adarshr:gradle-test-logger-plugin", version.ref = "testlogger-plugin" }
 tomlj = { module = "org.tomlj:tomlj", version.ref = "tomlj" }
 typesafe-config = { module = "com.typesafe:config", version.ref = "typesafe-config" }
-objenesis = { module = "org.objenesis:objenesis", version.ref = "objenesis" }
 maven-model-builder = { module = "org.apache.maven:maven-model-builder", version.ref = "maven-model-builder" }
 includegit-plugin = { module = "me.champeau.gradle.includegit:plugin", version.ref = "includegit" }
 sonatype-scan-plugin = { module = "org.sonatype.gradle.plugins:scan-gradle-plugin", version.ref = "sonatype-scan" }

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.build
 
 import com.diffplug.gradle.spotless.SpotlessTask
-import io.micronaut.build.utils.DefaultVersions
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -45,8 +44,6 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
                     'org.codehaus.groovy' :
                     'org.apache.groovy'
         }
-        def byteBuddyVersionProvider = versionProviderOrDefault(project, 'bytebuddy', List.of("libs", "mnTest"), DefaultVersions.BYTEBUDDY_VERSION)
-        def objenesisVersionProvider = versionProviderOrDefault(project, 'objenesis', List.of("libs", "mnTest"), DefaultVersions.OBJENESIS_VERSION)
         def logbackVersionProvider = versionProviderOrDefault(project, 'logback', List.of("libs", "mnLogging"), '')
 
         project.configurations {
@@ -86,15 +83,6 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
             })
             dependencies.addProvider("testCompileOnly", micronautVersionProvider.map { micronautVersion ->
                 "io.micronaut:micronaut-inject-groovy:${micronautVersion}"
-            })
-            dependencies.addProvider("testImplementation", groovyGroupProvider.zip(groovyVersionProvider) { groovyGroup, groovyVersion ->
-                "$groovyGroup:groovy-test:$groovyVersion"
-            })
-            dependencies.addProvider("testImplementation", byteBuddyVersionProvider.map {
-                optionalDependency("net.bytebuddy:byte-buddy", it)
-            })
-            dependencies.addProvider("testImplementation", objenesisVersionProvider.map {
-                optionalDependency("org.objenesis:objenesis", it)
             })
             dependencies.addProvider("testRuntimeOnly", logbackVersionProvider.map {
                 optionalDependency("ch.qos.logback:logback-classic", it)


### PR DESCRIPTION
This commit removes some automatic dependencies which were added to the test compile classpath:

- `groovy-test`, which is probably a dependency from the era where tests were using plain Groovy (no Spock, no JUnit). This was causing JUnit 4 to be on classpath, and some tests accidentally used wrong annotations and/or assertions, which was causing the tests to be ignored.
- `byte-buddy`
- `objenesis`

The last 2 being infrequently (if ever) used.