### PR TITLE
Introduce new base Java and Kotlin plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,14 @@ gradlePlugin {
             id = 'io.micronaut.build.internal.base-module'
             implementationClass = 'io.micronaut.build.MicronautBaseModulePlugin'
         }
+        'java-base' {
+            id = 'io.micronaut.build.internal.java-base'
+            implementationClass = 'io.micronaut.build.MicronautBuildJavaBasePlugin'
+        }
+        'kotlin-base' {
+            id = 'io.micronaut.build.internal.kotlin-base'
+            implementationClass = 'io.micronaut.build.MicronautBuildKotlinBasePlugin'
+        }
         module {
             id = 'io.micronaut.build.internal.module'
             implementationClass = 'io.micronaut.build.MicronautModulePlugin'

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -7,15 +7,12 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedComponentResult
-import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.diagnostics.DependencyReportTask
 import org.gradle.api.tasks.javadoc.Groovydoc
 import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.tasks.Jar
-import org.gradle.jvm.toolchain.JavaLanguageVersion
-import org.gradle.jvm.toolchain.JavaToolchainService
 
 import static io.micronaut.build.BomSupport.coreBomArtifactId
 import static io.micronaut.build.utils.VersionHandling.versionProviderOrDefault
@@ -104,87 +101,25 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
 
     @SuppressWarnings('GrDeprecatedAPIUsage')
     private void configureJavaPlugin(Project project, MicronautBuildExtension micronautBuildExtension) {
+        project.pluginManager.apply(MicronautBuildJavaBasePlugin)
         project.apply plugin: "groovy"
         project.apply plugin: "java-library"
-
-        def javaPluginExtension = project.extensions.findByType(JavaPluginExtension)
-        JavaToolchainService toolchains = project.getExtensions().getByType(JavaToolchainService.class);
-
-        project.afterEvaluate {
-            if (micronautBuildExtension.getUseToolchains().getOrElse(false)) {
-                javaPluginExtension.toolchain.languageVersion.convention(micronautBuildExtension.javaVersion.map(JavaLanguageVersion::of))
-            } else {
-                javaPluginExtension.sourceCompatibility = micronautBuildExtension.javaVersion.map(JavaLanguageVersion::of).get()
-                javaPluginExtension.targetCompatibility = micronautBuildExtension.javaVersion.map(JavaLanguageVersion::of).get()
-            }
-            if (micronautBuildExtension.sourceCompatibility.isPresent() || micronautBuildExtension.targetCompatibility.isPresent()) {
-                project.logger.warn """
-The "sourceCompatibility" and "targetCompatibility" properties are deprecated.
-Please use "micronautBuild.javaVersion" instead.
-You can do this directly in the project, or, better, in a convention plugin if it exists.
-"""
-                // Remove convention or Gradle will complain that you can't use both
-                javaPluginExtension.toolchain.languageVersion.convention(null)
-                javaPluginExtension.with {
-                    // orElse makes it work even if only one of the 2 properties is set
-                    sourceCompatibility = micronautBuildExtension.sourceCompatibility.orElse(micronautBuildExtension.targetCompatibility).get()
-                    targetCompatibility = micronautBuildExtension.targetCompatibility.orElse(micronautBuildExtension.sourceCompatibility).get()
-                }
-            }
-        }
-
-        def useVendorAsInput = project.providers.environmentVariable("MICRONAUT_TEST_USE_VENDOR")
-                .map(Boolean::parseBoolean).getOrElse(false)
-        project.tasks.withType(Test).configureEach {
-            jvmArgs '-Duser.country=US'
-            jvmArgs '-Duser.language=en'
-            useJUnitPlatform()
-            if (useVendorAsInput) {
-                // This will have to be changed once we switch to toolchain support, since it will not be relevant anymore
-                def vendor = project.providers.systemProperty("java.vendor").getOrElse("unknown")
-                println("Configuring test task ${it.path} to execute specifically for vendor: $vendor")
-                inputs.property("java.vendor", vendor)
-            }
-            if (extensions.findByName('develocity')) {
-                develocity.testRetry {
-                    if (micronautBuildExtension.environment.isGithubAction().getOrElse(false)) {
-                        maxRetries.set(2)
-                        maxFailures.set(20)
-                    }
-                    failOnPassedAfterRetry.set(false)
-                }
-                develocity.predictiveTestSelection {
-                    enabled = micronautBuildExtension.environment.isTestSelectionEnabled()
-                }
-                develocity.testDistribution {
-                    enabled = false
-                }
-            }
-        }
-        project.afterEvaluate { unused ->
-            project.tasks.withType(Test).configureEach {
-                if (micronautBuildExtension.getUseToolchains().getOrElse(false)) {
-                    javaLauncher.set(toolchains.launcherFor {
-                        languageVersion.set(micronautBuildExtension.testJavaVersion.map { JavaLanguageVersion.of(it) })
-                    })
-                }
-            }
-        }
 
         project.tasks.withType(GroovyCompile).configureEach {
             groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
         }
 
+        project.tasks.withType(Test).configureEach {
+            useJUnitPlatform()
+        }
+
         project.afterEvaluate {
             def compileOptions = micronautBuildExtension.compileOptions
             project.tasks.withType(JavaCompile).configureEach {
-                options.encoding = "UTF-8"
-                options.compilerArgs.add('-parameters')
                 if (micronautBuildExtension.enableProcessing.get()) {
                     options.compilerArgs.add("-Amicronaut.processing.group=$project.group".toString())
                     options.compilerArgs.add("-Amicronaut.processing.module=micronaut-$project.name".toString())
                 }
-                compileOptions.applyTo(options)
             }
             project.tasks.withType(GroovyCompile).configureEach {
                 compileOptions.applyTo(options)

--- a/src/main/java/io/micronaut/build/MicronautBuildJavaBasePlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildJavaBasePlugin.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.testing.Test;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+
+public class MicronautBuildJavaBasePlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        var pluginManager = project.getPluginManager();
+        // Using a String here because the class is still implemented in Groovy so
+        // not visible yet
+        pluginManager.apply("io.micronaut.build.internal.base");
+        pluginManager.apply(JavaPlugin.class);
+        var micronautBuild = project.getExtensions().findByType(MicronautBuildExtension.class);
+        configureJavaPlugin(project, micronautBuild);
+    }
+
+    private void configureJavaPlugin(Project project, MicronautBuildExtension micronautBuildExtension) {
+        var javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
+        var toolchains = project.getExtensions().getByType(JavaToolchainService.class);
+
+        project.afterEvaluate(p -> {
+            if (micronautBuildExtension.getUseToolchains().getOrElse(false)) {
+                javaPluginExtension.getToolchain().getLanguageVersion().convention(micronautBuildExtension.getJavaVersion().map(JavaLanguageVersion::of));
+            } else {
+                var javaVersion = micronautBuildExtension.getJavaVersion().map(JavaLanguageVersion::of).get();
+                javaPluginExtension.setSourceCompatibility(javaVersion);
+                javaPluginExtension.setTargetCompatibility(javaVersion);
+            }
+            if (micronautBuildExtension.getSourceCompatibility().isPresent() || micronautBuildExtension.getTargetCompatibility().isPresent()) {
+                project.getLogger().warn("""
+                    The "sourceCompatibility" and "targetCompatibility" properties are deprecated.
+                    Please use "micronautBuild.javaVersion" instead.
+                    You can do this directly in the project, or, better, in a convention plugin if it exists.
+                    """);
+                // Remove convention or Gradle will complain that you can't use both
+                javaPluginExtension.getToolchain().getLanguageVersion().convention((JavaLanguageVersion) null);
+                javaPluginExtension.setSourceCompatibility(micronautBuildExtension.getSourceCompatibility().orElse(micronautBuildExtension.getTargetCompatibility()).get());
+                javaPluginExtension.setTargetCompatibility(micronautBuildExtension.getTargetCompatibility().orElse(micronautBuildExtension.getSourceCompatibility()).get());
+            }
+        });
+
+        var useVendorAsInput = project.getProviders().environmentVariable("MICRONAUT_TEST_USE_VENDOR")
+            .map(Boolean::parseBoolean).getOrElse(false);
+        project.getTasks().withType(Test.class).configureEach(task -> {
+            task.jvmArgs("-Duser.country=US");
+            task.jvmArgs("-Duser.language=en");
+            task.useJUnitPlatform();
+            if (useVendorAsInput) {
+                // This will have to be changed once we switch to toolchain support, since it will not be relevant anymore
+                var vendor = project.getProviders().systemProperty("java.vendor").getOrElse("unknown");
+                System.out.println("Configuring test task " + task.getPath() + " to execute specifically for vendor: " + vendor);
+                task.getInputs().property("java.vendor", vendor);
+            }
+            if (task.getExtensions().findByName("develocity") != null) {
+                var develocity = task.getExtensions().getByType(DevelocityTestConfiguration.class);
+                develocity.testRetry(tr -> {
+                    if (micronautBuildExtension.getEnvironment().isGithubAction().getOrElse(false)) {
+                        tr.getMaxRetries().set(2);
+                        tr.getMaxFailures().set(20);
+                    }
+                    tr.getFailOnPassedAfterRetry().set(false);
+                });
+                develocity.predictiveTestSelection(pts -> pts.getEnabled().set(micronautBuildExtension.getEnvironment().isTestSelectionEnabled()));
+                develocity.getTestDistribution().getEnabled().set(false);
+            }
+        });
+        project.afterEvaluate(unused -> {
+                project.getTasks().withType(Test.class).configureEach(test -> {
+                if (micronautBuildExtension.getUseToolchains().getOrElse(false)) {
+                    test.getJavaLauncher().set(toolchains.launcherFor(spec -> spec.getLanguageVersion().set(micronautBuildExtension.getTestJavaVersion().map(JavaLanguageVersion::of))));
+                }
+            });
+        });
+
+        project.getTasks().withType(JavaCompile.class).configureEach(task -> {
+            var options = task.getOptions();
+            options.setEncoding("UTF-8");
+            options.getCompilerArgs().add("-parameters");
+            micronautBuildExtension.getCompileOptions().applyTo(options);
+        });
+    }
+
+}

--- a/src/main/java/io/micronaut/build/MicronautBuildKotlinBasePlugin.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildKotlinBasePlugin.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+
+/**
+ * Configures the Kotlin compiler to use the same Java version as the Java compiler.
+ * This is done using reflection because of Gradle classloading problems: we cannot add
+ * the Kotlin compiler as "implementation" dependency because it would make it available
+ * to all projects, preventing the use of another Kotlin plugin version.
+ *
+ * We can't make it compileOnly either, because the build plugins are loaded via a
+ * settings plugin which is found higher in the classloader hierarchy than the project
+ * plugins. Therefore, even if this code would compile, it would fail at runtime
+ * with NoClassDefFoundError.
+ */
+public class MicronautBuildKotlinBasePlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(MicronautBuildJavaBasePlugin.class);
+        project.getPluginManager().withPlugin("org.jetbrains.kotlin.jvm", unused -> {
+            try {
+                var micronautBuild = project.getExtensions().getByType(MicronautBuildExtension.class);
+                var kotlinExtension = project.getExtensions().findByName("kotlin");
+                if (kotlinExtension != null) {
+                    var getCompilerOptions = kotlinExtension.getClass().getMethod("getCompilerOptions");
+                    var compilerOptions = getCompilerOptions.invoke(kotlinExtension);
+                    var getJvmTarget = compilerOptions.getClass().getMethod("getJvmTarget");
+                    var jvmTarget = getJvmTarget.invoke(compilerOptions);
+                    var jvmTargetClass = kotlinExtension.getClass().getClassLoader().loadClass("org.jetbrains.kotlin.gradle.dsl.JvmTarget");
+                    var fromTarget = jvmTargetClass.getMethod("fromTarget", String.class);
+                    var javaVersion = micronautBuild.getJavaVersion().map(version -> {
+                        try {
+                            var versionAsString = version.toString();
+                            project.getLogger().info(String.format("Configuring Kotlin to target Java %s", versionAsString));
+                            return fromTarget.invoke(null, versionAsString);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                    var convention = jvmTarget.getClass().getMethod("convention", Provider.class);
+                    convention.invoke(jvmTarget, javaVersion);
+                } else {
+                    throw new RuntimeException("Kotlin project extension not found");
+                }
+            } catch (Exception e) {
+                throw new GradleException("Unable to configure Kotlin extension", e);
+            }
+        });
+    }
+}


### PR DESCRIPTION
This commit introduces a couple new plugins, which can be used for "test suites" or "doc examples" in Micronaut builds. Before this change, there wasn't any base plugin for these kind of projects. This means that everytime we update the Micronaut Build plugins to change the baseline, for example to Java 21 in Micronaut 5, then all build scripts of test suites or examples have to be aligned.

The 2 new plugins are:

- `io.micronaut.build.internal.java-base`, which can be applied to Java projects (which are NOT Micronaut modules)
- `io.micronaut.build.internal.kotlin-base`, which can be applied to Kotlin projects (in which case the Kotlin plugin needs to be applied on that project too)