### PR TITLE
Add default versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,16 @@ tasks.named('jar', Jar) {
 def generateVersions = tasks.register("generateVersions", VersionsWriterTask) {
     className = "io.micronaut.build.utils.DefaultVersions"
     outputDirectory = layout.buildDirectory.dir("generated/versions")
+    versions.put("micronaut_docs", libs.versions.micronaut.docs)
+    versions.put("micronaut_logging", libs.versions.micronaut.logging)
+    versions.put("micronaut_test", libs.versions.micronaut.test)
+    versions.put("groovy", libs.versions.groovy)
+    versions.put("spock", libs.versions.spock)
+    versions.put("junit5_platform", libs.versions.junit5.platform)
+    versions.put("junit5", libs.versions.junit5.asProvider())
+    versions.put("junit6", libs.versions.junit6)
+    versions.put("checkstyle", libs.versions.checkstyle)
+    versions.put("logback", libs.versions.logback)
 }
 
 sourceSets.main.java.srcDir(generateVersions)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,17 @@ typesafe-config = "1.4.5"
 maven-model-builder = "3.9.11"
 includegit = "0.3.0"
 sonatype-scan = "3.0.0"
-errorprone="4.3.0"
-bouncycastle="1.82"
+errorprone = "4.3.0"
+bouncycastle = "1.82"
+micronaut-docs = "3.0.0"
+micronaut-test = "4.10.2"
+micronaut-logging = "1.7.1"
+groovy = "4.0.29"
+junit5 = "5.14.0"
+junit5-platform = "1.14.0"
+junit6 = "6.0.0"
+logback = "1.5.20"
+checkstyle = "12.1.0"
 
 [libraries]
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
@@ -43,8 +52,22 @@ typesafe-config = { module = "com.typesafe:config", version.ref = "typesafe-conf
 maven-model-builder = { module = "org.apache.maven:maven-model-builder", version.ref = "maven-model-builder" }
 includegit-plugin = { module = "me.champeau.gradle.includegit:plugin", version.ref = "includegit" }
 sonatype-scan-plugin = { module = "org.sonatype.gradle.plugins:scan-gradle-plugin", version.ref = "sonatype-scan" }
-bc-prov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle"}
-bc-pkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle"}
+bc-prov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+bc-pkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
+micronaut-docs = { module = "io.micronaut.docs:micronaut-docs-asciidoc-config-props", version.ref = "micronaut-docs" }
+micronaut-logging = { module = "io.micronaut.logging:micronaut-logging", version.ref = "micronaut-logging" }
+micronaut-test = { module = "io.micronaut.test:micronaut-test", version.ref = "micronaut-test" }
+groovy = { module = "org.codehaus.groovy:groovy-core", version.ref = "groovy" }
 
+junit5-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit5-platform" }
+junit5-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
+junit5-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
+
+junit6-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit6" }
+junit6-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit6" }
+junit6-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit6" }
+
+logback = { module = "ch.qos.logback:logback-core", version.ref = "logback" }
+checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle"}
 [bundles]
 bouncycastle = ["bc-prov", "bc-pkix"]

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.build
 
 import com.diffplug.gradle.spotless.SpotlessTask
+import io.micronaut.build.utils.DefaultVersions
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -35,13 +36,13 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
     private void configureDependencies(Project project, MicronautBuildExtension micronautBuild) {
         def micronautVersionProvider = versionProviderOrDefault(project, 'micronaut', '')
         // The Groovy version comes from core if not defined locally
-        def groovyVersionProvider = versionProviderOrDefault(project, 'groovy', List.of("libs", "mn"), '')
+        def groovyVersionProvider = versionProviderOrDefault(project, 'groovy', List.of("libs", "mn"), DefaultVersions.GROOVY_VERSION)
         def groovyGroupProvider = groovyVersionProvider.map { groovyVersion ->
             groovyVersion.split("\\.").first().toInteger() <= 3 ?
                     'org.codehaus.groovy' :
                     'org.apache.groovy'
         }
-        def logbackVersionProvider = versionProviderOrDefault(project, 'logback', List.of("libs", "mnLogging"), '')
+        def logbackVersionProvider = versionProviderOrDefault(project, 'logback', List.of("libs", "mnLogging"), DefaultVersions.LOGBACK_VERSION)
 
         project.configurations {
             documentation

--- a/src/main/groovy/io/micronaut/build/MicronautModulePlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautModulePlugin.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.build
 
 import groovy.transform.CompileStatic
+import io.micronaut.build.utils.DefaultVersions
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -27,20 +28,25 @@ class MicronautModulePlugin implements Plugin<Project> {
         var deps = project.dependencies
         deps.with {
             add("annotationProcessor", "io.micronaut:micronaut-inject-java")
-            addProvider("annotationProcessor", versionProviderOrDefault(project, 'micronaut-docs', '').map { "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$it" })
+            addProvider("annotationProcessor", versionProviderOrDefault(project, 'micronaut-docs', DefaultVersions.MICRONAUT_DOCS_VERSION).map { "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$it" })
             add("api", "io.micronaut:micronaut-inject")
         }
         project.configurations.getByName("testImplementation").dependencies.addAllLater(
                 micronautBuild.testFramework.map {
                     if (it == TestFramework.SPOCK) {
                         return List.of(
-                                deps.create(versionProviderOrDefault(project, 'spock', '').map { "org.spockframework:spock-core:${it}" }.get()),
-                                deps.create(versionProviderOrDefault(project, 'micronaut-test', '').map { "io.micronaut.test:micronaut-test-spock:${it}" }.get())
+                                deps.create(versionProviderOrDefault(project, 'spock', DefaultVersions.SPOCK_VERSION).map { "org.spockframework:spock-core:${it}" }.get()),
+                                deps.create(versionProviderOrDefault(project, 'micronaut-test', DefaultVersions.MICRONAUT_TEST_VERSION).map { "io.micronaut.test:micronaut-test-spock:${it}" }.get())
                         )
                     } else if (it == TestFramework.JUNIT5) {
                         return List.of(
-                                deps.create(versionProviderOrDefault(project, 'junit5', 'unknown').map { "org.junit.jupiter:junit-jupiter-api:${it}" }.get()),
-                                deps.create(versionProviderOrDefault(project, 'micronaut-test', '').map { "io.micronaut.test:micronaut-test-junit5:${it}" }.get())
+                                deps.create(versionProviderOrDefault(project, 'junit5', DefaultVersions.JUNIT5_VERSION).map { "org.junit.jupiter:junit-jupiter-api:${it}" }.get()),
+                                deps.create(versionProviderOrDefault(project, 'micronaut-test', DefaultVersions.MICRONAUT_TEST_VERSION).map { "io.micronaut.test:micronaut-test-junit5:${it}" }.get())
+                        )
+                    } else if (it == TestFramework.JUNIT6) {
+                        return List.of(
+                                deps.create(versionProviderOrDefault(project, 'junit6', DefaultVersions.JUNIT6_VERSION).map { "org.junit.jupiter:junit-jupiter-api:${it}" }.get()),
+                                deps.create(versionProviderOrDefault(project, 'micronaut-test', DefaultVersions.MICRONAUT_TEST_VERSION).map { "io.micronaut.test:micronaut-test-junit5:${it}" }.get())
                         )
                     } else {
                         throw new GradleException("Unsupported test framework: $it")
@@ -53,8 +59,13 @@ class MicronautModulePlugin implements Plugin<Project> {
                         return List.<Dependency>of()
                     } else if (it == TestFramework.JUNIT5) {
                         return List.of(
-                                deps.create(versionProviderOrDefault(project, 'junit-platform-launcher', '1.12.0').map { "org.junit.platform:junit-platform-launcher:${it}" }.get()),
-                                deps.create(versionProviderOrDefault(project, 'junit5', 'unknown').map { "org.junit.jupiter:junit-jupiter-engine:${it}" }.get()),
+                                deps.create(versionProviderOrDefault(project, 'junit-platform-launcher', DefaultVersions.JUNIT5_PLATFORM_VERSION).map { "org.junit.platform:junit-platform-launcher:${it}" }.get()),
+                                deps.create(versionProviderOrDefault(project, 'junit5', DefaultVersions.JUNIT5_VERSION).map { "org.junit.jupiter:junit-jupiter-engine:${it}" }.get()),
+                        )
+                    } else if (it == TestFramework.JUNIT6) {
+                        return List.of(
+                                deps.create(versionProviderOrDefault(project, 'junit6', DefaultVersions.JUNIT6_VERSION).map { "org.junit.platform:junit-platform-launcher:${it}" }.get()),
+                                deps.create(versionProviderOrDefault(project, 'junit6', DefaultVersions.JUNIT6_VERSION).map { "org.junit.jupiter:junit-jupiter-engine:${it}" }.get()),
                         )
                     } else {
                         throw new GradleException("Unsupported test framework: $it")

--- a/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -3,6 +3,7 @@ package io.micronaut.build;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import io.micronaut.build.pom.BomSuppressions;
+import io.micronaut.build.utils.DefaultVersions;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.artifacts.ResolutionStrategy;
@@ -16,7 +17,6 @@ public abstract class MicronautBuildExtension {
 
   public static final String DEFAULT_DEPENDENCY_UPDATES_PATTERN = "(?i).+(-|\\.?)(b|M|RC|Dev)\\d?.*";
   public static final int DEFAULT_JAVA_VERSION = 21;
-  public static final String DEFAULT_CHECKSTYLE_VERSION = "11.0.1";
 
   private final BuildEnvironment environment;
 
@@ -34,7 +34,7 @@ public abstract class MicronautBuildExtension {
 
     getJavaVersion().convention(DEFAULT_JAVA_VERSION);
     getTestJavaVersion().convention(Integer.valueOf(JavaVersion.current().getMajorVersion()));
-    getCheckstyleVersion().convention(DEFAULT_CHECKSTYLE_VERSION);
+    getCheckstyleVersion().convention(DefaultVersions.CHECKSTYLE_VERSION);
     getDependencyUpdatesPattern().convention(DEFAULT_DEPENDENCY_UPDATES_PATTERN);
     getEnforcedPlatform().convention(false);
     getEnableProcessing().convention(false);

--- a/src/main/java/io/micronaut/build/MicronautBuildSettingsExtension.java
+++ b/src/main/java/io/micronaut/build/MicronautBuildSettingsExtension.java
@@ -19,6 +19,7 @@ import io.micronaut.build.catalogs.internal.LenientVersionCatalogParser;
 import io.micronaut.build.catalogs.internal.RichVersion;
 import io.micronaut.build.catalogs.internal.VersionCatalogTomlModel;
 import io.micronaut.build.catalogs.internal.VersionModel;
+import io.micronaut.build.utils.DefaultVersions;
 import io.micronaut.build.utils.IncludedBuildSupport;
 import me.champeau.gradle.igp.GitIncludeExtension;
 import org.apache.commons.lang3.StringUtils;
@@ -170,18 +171,18 @@ public abstract class MicronautBuildSettingsExtension {
     }
 
     private String determineMicronautVersion() {
-        return determineMicronautVersion("micronaut");
+        return determineMicronautVersion("micronaut", null);
     }
 
     private String determineMicronautTestVersion() {
-        return determineMicronautVersion("micronaut-test");
+        return determineMicronautVersion("micronaut-test", DefaultVersions.MICRONAUT_TEST_VERSION);
     }
 
     private String determineMicronautLoggingVersion() {
-        return determineMicronautVersion("micronaut-logging");
+        return determineMicronautVersion("micronaut-logging", DefaultVersions.MICRONAUT_LOGGING_VERSION);
     }
 
-    private String determineMicronautVersion(String moduleNameKebabCase) {
+    private String determineMicronautVersion(String moduleNameKebabCase, String defaultVersion) {
         Optional<String> micronautVersion = Optional.empty();
         if (versionCatalogTomlModel != null) {
             Optional<VersionModel> micronaut = versionCatalogTomlModel.findVersion(moduleNameKebabCase);
@@ -198,7 +199,7 @@ public abstract class MicronautBuildSettingsExtension {
                                      + "Version";
             micronautVersion = Optional.ofNullable(getProviders().gradleProperty(capitalizedName).getOrNull());
         }
-        return micronautVersion.orElse(null);
+        return micronautVersion.orElse(defaultVersion);
     }
 
     /**

--- a/src/main/java/io/micronaut/build/TestFramework.java
+++ b/src/main/java/io/micronaut/build/TestFramework.java
@@ -17,5 +17,6 @@ package io.micronaut.build;
 
 public enum TestFramework {
     SPOCK,
-    JUNIT5
+    JUNIT5,
+    JUNIT6
 }


### PR DESCRIPTION
This commit adds a number of default versions for `micronaut-docs`, `micronaut-logging`, `micronaut-test`, `groovy`, `spock`, `junit5`, `junit6` and `logback`.

This makes it redundant to define them in projects, but will require more frequent upgrades of Micronaut Build in case we want to force bump all versions.

There is a new choice for JUnit which is to use JUnit 6.

There is NO default version for Kotlin yet, because the version is not a simple dependency: it's a build plugin.