### PR TITLE
add back byte-buddy and objenesis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,8 @@ tasks.named('jar', Jar) {
 }
 
 def generateVersions = tasks.register("generateVersions", VersionsWriterTask) {
+    versions.put("bytebuddy", libs.versions.bytebuddy)
+    versions.put("objenesis", libs.versions.objenesis)
     className = "io.micronaut.build.utils.DefaultVersions"
     outputDirectory = layout.buildDirectory.dir("generated/versions")
     versions.put("micronaut_docs", libs.versions.micronaut.docs)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,8 @@ spotless-plugin = "7.2.1"
 testlogger-plugin = "4.0.0"
 tomlj = "1.1.1"
 typesafe-config = "1.4.5"
+bytebuddy = "1.17.8"
+objenesis = "3.4"
 maven-model-builder = "3.9.11"
 includegit = "0.3.0"
 sonatype-scan = "3.0.0"
@@ -32,6 +34,7 @@ checkstyle = "12.1.0"
 
 [libraries]
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
+bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 japicmp-plugin = { module = "me.champeau.gradle:japicmp-gradle-plugin", version.ref = "japicmp-plugin" }
 gradle-custom-userdata-plugin = { module = "com.gradle:common-custom-user-data-gradle-plugin", version.ref = "gradle-custom-userdata-plugin" }
@@ -49,6 +52,7 @@ spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", ver
 testlogger-plugin = { module = "com.adarshr:gradle-test-logger-plugin", version.ref = "testlogger-plugin" }
 tomlj = { module = "org.tomlj:tomlj", version.ref = "tomlj" }
 typesafe-config = { module = "com.typesafe:config", version.ref = "typesafe-config" }
+objenesis = { module = "org.objenesis:objenesis", version.ref = "objenesis" }
 maven-model-builder = { module = "org.apache.maven:maven-model-builder", version.ref = "maven-model-builder" }
 includegit-plugin = { module = "me.champeau.gradle.includegit:plugin", version.ref = "includegit" }
 sonatype-scan-plugin = { module = "org.sonatype.gradle.plugins:scan-gradle-plugin", version.ref = "sonatype-scan" }

--- a/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -43,7 +43,8 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
                     'org.apache.groovy'
         }
         def logbackVersionProvider = versionProviderOrDefault(project, 'logback', List.of("libs", "mnLogging"), DefaultVersions.LOGBACK_VERSION)
-
+        def byteBuddyVersionProvider = versionProviderOrDefault(project, 'bytebuddy', List.of("libs", "mnTest"), DefaultVersions.BYTEBUDDY_VERSION)
+        def objenesisVersionProvider = versionProviderOrDefault(project, 'objenesis', List.of("libs", "mnTest"), DefaultVersions.OBJENESIS_VERSION)
         project.configurations {
             documentation
             globalBoms {
@@ -81,6 +82,12 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
             })
             dependencies.addProvider("testCompileOnly", micronautVersionProvider.map { micronautVersion ->
                 "io.micronaut:micronaut-inject-groovy:${micronautVersion}"
+            })
+            dependencies.addProvider("testImplementation", byteBuddyVersionProvider.map {
+                optionalDependency("net.bytebuddy:byte-buddy", it)
+            })
+            dependencies.addProvider("testImplementation", objenesisVersionProvider.map {
+                optionalDependency("org.objenesis:objenesis", it)
             })
             dependencies.addProvider("testRuntimeOnly", logbackVersionProvider.map {
                 optionalDependency("ch.qos.logback:logback-classic", it)


### PR DESCRIPTION
https://spockframework.org/spock/docs/2.0/faq.html#_what_are_spocks_optional_dependencies_used_for

> Objenesis (artifact org.objenesis:objenesis) is required for mocking classes without default constructors.

> Either ByteBuddy (artifact net.bytebuddy:byte-buddy) or CGLIB (artifact cglib:cglib-nodep) are required for mocking classes and not just interfaces.