### PR TITLE
Generate Micronaut Module Info descriptors

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 asciidoctorj = "3.0.0"
 commons-lang3 = "3.18.0"
+commons-text = "1.14.0"
 japicmp-plugin = "0.4.6"
 gradle-custom-userdata-plugin = "2.3"
 develocity-plugin = "4.2.2"
@@ -38,6 +39,7 @@ kotlin-ksp = "2.2.21-2.0.4"
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
 bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
+commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
 japicmp-plugin = { module = "me.champeau.gradle:japicmp-gradle-plugin", version.ref = "japicmp-plugin" }
 gradle-custom-userdata-plugin = { module = "com.gradle:common-custom-user-data-gradle-plugin", version.ref = "gradle-custom-userdata-plugin" }
 develocity-plugin = { module = "com.gradle:develocity-gradle-plugin", version.ref = "develocity-plugin" }

--- a/micronaut-gradle-plugins/build.gradle.kts
+++ b/micronaut-gradle-plugins/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
         }
     }
     implementation(libs.commons.lang3)
+    implementation(libs.commons.text)
     implementation(libs.snakeyaml)
     implementation(libs.grails.gdoc)
     implementation(libs.asciidoctorj)

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
@@ -2,6 +2,7 @@ package io.micronaut.build
 
 import groovy.transform.CompileStatic
 import io.micronaut.build.compat.MicronautBinaryCompatibilityPlugin
+import io.micronaut.build.info.MicronautModuleInfoPlugin
 import io.micronaut.build.pom.PomCheckerUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -24,6 +25,7 @@ class MicronautBaseModulePlugin implements Plugin<Project> {
         project.pluginManager.apply(MicronautPublishingPlugin)
         project.pluginManager.apply(MicronautBinaryCompatibilityPlugin)
         project.pluginManager.apply(SonatypeConfigurationPlugin)
+        project.pluginManager.apply(MicronautModuleInfoPlugin)
         configureJUnit(project)
         assertSettingsPluginApplied(project)
         project.pluginManager.withPlugin("maven-publish") {

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/info/MicronautModuleInfoExtension.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/info/MicronautModuleInfoExtension.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.info;
+
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+
+/**
+ * This extension can be used to configure the project
+ * Micronaut Module Info descriptor. That descriptor
+ * is used at runtime to provide information about Micronaut
+ * modules which are found on classpath.
+ *
+ * All parameters are configured with reasonable
+ * defaults, but you may want to override the parent
+ * module id, for example, if a project wants to expose
+ * some modules as children of another module.
+ *
+ */
+public interface MicronautModuleInfoExtension {
+    /**
+     * Determines if module descriptor generation is enabled.
+     * @return the enabled property
+     */
+    Property<Boolean> getEnabled();
+
+    /**
+     * The package name of the descriptor. By default, it is
+     * derived from the group id: groupid + .info
+     * @return the package name
+     */
+    Property<String> getPackageName();
+
+    /**
+     * The class name of the generated descriptor. By default,
+     * derived from the project name.
+     * @return the class name
+     */
+    Property<String> getClassName();
+
+    /**
+     * The human readable name of this module. Since we
+     * don't have such a thing now, it currently defaults
+     * to the project name.
+     * @return the module name
+     */
+    Property<String> getModuleName();
+
+    /**
+     * The module version.
+     * @return The module version
+     */
+    Property<String> getModuleVersion();
+
+    /**
+     * The description of the module. By default uses the project's
+     * description.
+     * @return the module description
+     */
+    Property<String> getModuleDescription();
+
+    /**
+     * The project group id. Shouldn't be changed unless you know
+     * what you are doing.
+     * @return the group id
+     */
+    Property<String> getGroupId();
+
+    /**
+     * The project artifact id. Should't be changed unless you know
+     * what you are doing.
+     * @return the artifact id
+     */
+    Property<String> getArtifactId();
+
+    /**
+     * The parent module id. By default, defauts to the project
+     * of the multi-project build which is the "-core" module.
+     * It is possible to create a deeper hierarchy. The id must
+     * consist of the group id:artifact id
+     * @return the parent module id
+     */
+    Property<String> getParentModuleId();
+
+    /**
+     * Tags for the module. For now purely informative, may be
+     * used for filtering.
+     * @return the module tags
+     */
+    SetProperty<String> getTags();
+}

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/info/MicronautModuleInfoGeneratorTask.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/info/MicronautModuleInfoGeneratorTask.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.info;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.text.StringEscapeUtils.escapeJava;
+
+@CacheableTask
+public abstract class MicronautModuleInfoGeneratorTask extends DefaultTask {
+    @Input
+    public abstract Property<String> getPackageName();
+
+    @Input
+    public abstract Property<String> getClassName();
+
+    @Input
+    public abstract Property<String> getModuleName();
+
+    @Input
+    public abstract Property<String> getModuleVersion();
+
+    @Input
+    public abstract Property<String> getModuleDescription();
+
+    @Input
+    public abstract Property<String> getGroupId();
+
+    @Input
+    public abstract Property<String> getArtifactId();
+
+    @Input
+    @Optional
+    public abstract Property<String> getParentModuleId();
+
+    @Input
+    public abstract SetProperty<String> getTags();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDirectory();
+
+    @Inject
+    public abstract FileSystemOperations getFsOperations();
+
+    public MicronautModuleInfoGeneratorTask() {
+        setDescription("Generates a Micronaut Module Info descriptor");
+    }
+
+    @TaskAction
+    public void generateDescriptor() throws IOException {
+        getFsOperations().delete(spec -> spec.delete(getOutputDirectory()));
+        var packageName = getPackageName().get();
+        var packageDir = packageName.replace('.', '/');
+        var outputDir = getOutputDirectory().get().getAsFile().toPath().resolve(packageDir);
+        Files.createDirectories(outputDir);
+        var className = getClassName().get();
+        var fileName = className + ".java";
+
+        var groupId = getGroupId().get();
+        var artifactId = getArtifactId().get();
+        var ga = groupId + ":" + artifactId;
+        var name = escapeJava(getModuleName().get());
+        var description = escapeJava(removeExtraNewLines(getModuleDescription().get()));
+        var version = getModuleVersion().get();
+        var mavenCoords = "new MavenCoordinates(\"" + groupId + "\", \"" + artifactId + "\", \"" + version + "\")";
+        var parent = getParentModuleId().map(id -> {
+            if (id.equals(ga)) {
+                // Parent is the same module. To be safe, set it to null to avoid cyclic dependency.
+                return "null";
+            } else {
+                return "\"" + id + "\"";
+            }
+        }).getOrElse("null");
+        var tags = "Set.of(" + getTags().get().stream().map(tag -> "\"" + escapeJava(tag) + "\"").collect(Collectors.joining(",")) + ")";
+
+        try (var writer = new PrintWriter(Files.newBufferedWriter(outputDir.resolve(fileName), StandardCharsets.UTF_8))) {
+            writer.println("package " + packageName + ";");
+            writer.println();
+            writer.println("import io.micronaut.module.info.AbstractMicronautModuleInfo;");
+            writer.println("import io.micronaut.module.info.MavenCoordinates;");
+            writer.println("import java.util.Set;");
+            writer.println();
+            writer.println("public class " + className + " extends AbstractMicronautModuleInfo {");
+            writer.println("    public " + className + "() {");
+            writer.println("        super(\"" + ga + "\", ");
+            writer.println("              \"" + name + "\",");
+            writer.println("              \"" + description + "\",");
+            writer.println("              \"" + version + "\",");
+            writer.println("              " + mavenCoords + ",");
+            writer.println("              " + parent + ",");
+            writer.println("              " + tags);
+            writer.println("        );");
+            writer.println("    }");
+            writer.println("}");
+        }
+
+        var metaInfDir = outputDir.resolve("META-INF/services");
+        Files.createDirectories(metaInfDir);
+        try (var writer = new PrintWriter(Files.newBufferedWriter(metaInfDir.resolve("io.micronaut.module.info.MicronautModuleInfo"), StandardCharsets.UTF_8))) {
+            writer.println(packageName + "." + className);
+        }
+    }
+
+    private static String removeExtraNewLines(String input) {
+        return input.replaceAll("^[\\r\\n]+|[\\r\\n]+$", "");
+    }
+}

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/info/MicronautModuleInfoPlugin.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/info/MicronautModuleInfoPlugin.java
@@ -117,13 +117,15 @@ public class MicronautModuleInfoPlugin implements Plugin<Project> {
                     }
 
                     throw new IllegalArgumentException("""
-                Unable to determine core project. You have to set the core project explicitly on the micronautBuild extension. For example:
+                Unable to determine the main subproject. You have to set the main subproject explicitly on the micronautBuild extension. For example:
                 
                 micronautBuild {
                    descriptor {
                        parentModuleId = "io.micronaut.foo:micronaut-foo-core"
                    }
                 }
+                
+                The main subproject corresponds, in the multiproject build, to the project which is the "main" one, typically the core module, but NOT the BOM.
                 """);
                 }));
                 var generator = project.getTasks().register("generateMicronautDescriptor", MicronautModuleInfoGeneratorTask.class, task -> {

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/info/MicronautModuleInfoPlugin.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/info/MicronautModuleInfoPlugin.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.info;
+
+import io.micronaut.build.MicronautBuildExtension;
+import io.micronaut.build.utils.VersionParser;
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.Provider;
+
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import static io.micronaut.build.utils.VersionHandling.versionProviderOrDefault;
+
+/**
+ * A plugin which generates a Micronaut module descriptor for the project.
+ */
+public class MicronautModuleInfoPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        var pluginManager = project.getPluginManager();
+        // Using a String here because the class is still implemented in Groovy so not visible yet
+        pluginManager.apply("io.micronaut.build.internal.base");
+        pluginManager.apply(JavaPlugin.class);
+        var micronautBuild = project.getExtensions().findByType(MicronautBuildExtension.class);
+        var infoExtension = ((ExtensionAware) micronautBuild).getExtensions().create("descriptor", MicronautModuleInfoExtension.class);
+        // Module descriptor generation is only enabled if compiling against Micronaut 5+
+        infoExtension.getEnabled().convention(includedCoreVersion(project).orElse(versionProviderOrDefault(project, "micronaut", "")).map(v -> {
+            var version = VersionParser.parse(v.replaceAll("-(SNAPSHOT|M[0-9]+)", ""));
+            var minimalVersion = VersionParser.parse("5.0.0");
+            return version.compareTo(minimalVersion) >= 0;
+        }));
+        configureDescriptorGeneration(infoExtension, project);
+    }
+
+    private static Provider<String> includedCoreVersion(Project p) {
+        return p.provider(() -> {
+            var includedBuilds = p.getGradle().getIncludedBuilds();
+            for (var includedBuild : includedBuilds) {
+                if (includedBuild.getName().equals("micronaut-core")) {
+                    var path = includedBuild.getProjectDir().toPath();
+                    var gradleProperties = new Properties();
+                    try (var reader = Files.newBufferedReader(path.resolve("gradle.properties"))) {
+                        gradleProperties.load(reader);
+                    }
+                    return gradleProperties.getProperty("projectVersion");
+
+                }
+            }
+            return null;
+        });
+    }
+
+    private void configureDescriptorGeneration(MicronautModuleInfoExtension info, Project project) {
+        project.afterEvaluate(unused -> {
+            if (info.getEnabled().getOrElse(true)) {
+                project.getDependencies().add("compileOnly", "io.micronaut:micronaut-module-info");
+                info.getModuleDescription().convention(project.provider(project::getDescription).orElse(project.getProviders().gradleProperty("projectDesc")));
+                info.getModuleName().convention(project.provider(project::getName));
+                info.getGroupId().convention(project.provider(() -> String.valueOf(project.getGroup())));
+                info.getArtifactId().convention(project.provider(() -> determineArtifactId(project)));
+                info.getModuleVersion().convention(project.provider(() -> String.valueOf(project.getVersion())));
+                info.getPackageName().convention(project.provider(() -> {
+                    var baseName = String.valueOf(project.getGroup());
+                    return baseName.replace('-', '.') + ".info";
+                }));
+                info.getClassName().convention(info.getArtifactId().map(name -> {
+                    var parts = name.split("[^a-zA-Z0-9]");
+                    return Arrays.stream(parts)
+                               .map(StringUtils::capitalize)
+                               .collect(Collectors.joining()) + "ModuleInfo";
+                }));
+                var parentName = project.getRootProject().getName();
+                var parentBaseName = parentName.substring(0, parentName.lastIndexOf("-parent"));
+                info.getParentModuleId().convention(project.provider(() -> {
+                    var candidates = new ArrayList<Project>();
+                    for (var p : project.getRootProject().getAllprojects()) {
+                        if (p.getName().equals(parentBaseName + "-core") || p.getName().equals("micronaut-" + parentBaseName + "-core")) {
+                            candidates.add(p);
+                        }
+                    }
+                    if (candidates.isEmpty()) {
+                        for (var p : project.getRootProject().getAllprojects()) {
+                            if (p.getName().equals("micronaut-" + parentBaseName) || p.getName().equals(parentBaseName)) {
+                                candidates.add(p);
+                            }
+                        }
+                    }
+                    if (candidates.size() == 1) {
+                        var p = candidates.getFirst();
+                        if (p == project) {
+                            // This is the main module, so it is the parent
+                            return null;
+                        }
+                        return p.getGroup() + ":" + determineArtifactId(p);
+                    }
+
+                    throw new IllegalArgumentException("""
+                Unable to determine core project. You have to set the core project explicitly on the micronautBuild extension. For example:
+                
+                micronautBuild {
+                   descriptor {
+                       parentModuleId = "io.micronaut.foo:micronaut-foo-core"
+                   }
+                }
+                """);
+                }));
+                var generator = project.getTasks().register("generateMicronautDescriptor", MicronautModuleInfoGeneratorTask.class, task -> {
+                    task.getModuleDescription().convention(info.getModuleDescription());
+                    task.getModuleName().convention(info.getModuleName());
+                    task.getGroupId().convention(info.getGroupId());
+                    task.getArtifactId().convention(info.getArtifactId());
+                    task.getModuleVersion().convention(info.getModuleVersion());
+                    task.getPackageName().convention(info.getPackageName());
+                    task.getClassName().convention(info.getClassName());
+                    task.getParentModuleId().convention(info.getParentModuleId());
+                    task.getTags().convention(info.getTags());
+                    task.getOutputDirectory().convention(project.getLayout().getBuildDirectory().dir("generated/sources/mn-descriptor"));
+                });
+                var javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
+                var mainSourceSet = javaPluginExtension.getSourceSets().getByName("main");
+                mainSourceSet.getJava().srcDir(generator);
+            }
+        });
+    }
+
+    private static String determineArtifactId(Project project) {
+        if (project.getName().startsWith("micronaut-")) {
+            return project.getName();
+        }
+        return "micronaut-" + project.getName();
+    }
+}


### PR DESCRIPTION
This is the Micronaut Build side of https://github.com/micronaut-projects/micronaut-core/pull/12192

An extension is added on `micronautBuild` which allows configuring the descriptor. By default, it will use the group id and artifact id of each module of the project to generate a descriptor. If a project is named `-core`, then it is considered the parent of other modules of a project. This is done because neither the `bom` nor the real `parent` project are shipped with a jar which could carry the parent descriptor. Therefore, we consider that the `core` module of a project is its parent. Then all other modules are children of it.