### PR TITLE
Initial support for language specific guides.

### DIFF
--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
@@ -107,16 +107,18 @@ abstract class MicronautDocsPlugin implements Plugin<Project> {
                 t.inputs.files(processConfigPropsTask.map(Copy::getDestinationDir))
                 t.inputs.property("Project description", projectDesc)
                 t.inputs.property("Kafka version", kafkaVersion)
-                t.targetDir = layout.buildDirectory.dir("working/02-docs-raw")
+                // DocPublisher adds the language as a subdir if set.
+                t.language = lang
+                if (lang)
+                    t.targetDir = layout.buildDirectory.dir("working/02-docs-raw")
+                else
+                    t.targetDir = layout.buildDirectory.dir("working/02-docs-raw/all")
                 String githubBranch = 'git rev-parse --abbrev-ref HEAD'.execute()?.text?.trim() ?: 'master'
                 t.sourceRepo = "https://github.com/${githubSlug}/edit/${githubBranch}/src/main/docs"
                 t.sourceDir = layout.projectDirectory.dir("src/main/docs")
                 t.resourcesDir = prepareDocsResources.flatMap(PrepareDocResourcesTask::getOutputDirectory)
                 t.propertiesFiles.from(rootProject.file("gradle.properties"))
                 t.asciidoc = true
-                if (lang != "") {
-                    t.language = lang
-                }
                 t.properties.putAll([
                         'safe': 'UNSAFE',
                         'source-highlighter': 'highlightjs',
@@ -134,18 +136,16 @@ abstract class MicronautDocsPlugin implements Plugin<Project> {
                         'grailsapi': 'http://docs.grails.org/latest/api/',
                         'gormapi': 'http://gorm.grails.org/latest/api/',
                         'springapi': 'https://docs.spring.io/spring/docs/current/javadoc-api/',
-                        'kafka-version': kafkaVersion
+                        'kafka-version': kafkaVersion,
+                        'default-language': lang ? lang : ''
                 ])
-                if (lang != "") {
-                    t.properties.put('default-language', lang)
-                }
             }
 
             // The empty language is the guide for all languages.
             def langs = [""] + LanguageSnippetMacro.LANGS
             def publishGuideByLang = langs.collectEntries { lang ->
                 [(lang): tasks.register("publishGuide${lang.capitalize()}", PublishGuideTask) {
-                    configureGuideTask(it as PublishGuideTask, lang)
+                    configureGuideTask(it as PublishGuideTask, lang ?: null)
                 }]
             }
             def publishGuide = publishGuideByLang[""]

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
@@ -9,6 +9,7 @@ import io.micronaut.build.docs.ValidateAsciidocOutputTask
 import io.micronaut.build.docs.props.MergeConfigurationReferenceTask
 import io.micronaut.build.docs.props.PublishConfigurationReferenceTask
 import io.micronaut.build.utils.GitHubApiService
+import io.micronaut.docs.LanguageSnippetMacro
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileTreeElement
@@ -98,24 +99,25 @@ abstract class MicronautDocsPlugin implements Plugin<Project> {
                 into(processConfigPropsOutputDir)
             }
 
-            def publishGuide = tasks.register('publishGuide', PublishGuideTask) {
-                group = DOCUMENTATION_GROUP
-                description = 'Generate Guide'
-
+            // Common configuration for PublishGuideTask, optionally per-language
+            def configureGuideTask = { PublishGuideTask t, String lang ->
+                t.group = DOCUMENTATION_GROUP
+                t.description = lang ? "Generate Guide (${lang})" : 'Generate Guide'
                 def kafkaVersion = rootProject.hasProperty('kafkaVersion') ? rootProject.properties['kafkaVersion'] : 'N/A'
-
-                inputs.files(processConfigPropsTask.map(Copy::getDestinationDir))
-                inputs.property("Project description", projectDesc)
-                inputs.property("Kafka version", kafkaVersion)
-
-                targetDir = layout.buildDirectory.dir("working/02-docs-raw")
+                t.inputs.files(processConfigPropsTask.map(Copy::getDestinationDir))
+                t.inputs.property("Project description", projectDesc)
+                t.inputs.property("Kafka version", kafkaVersion)
+                t.targetDir = layout.buildDirectory.dir("working/02-docs-raw")
                 String githubBranch = 'git rev-parse --abbrev-ref HEAD'.execute()?.text?.trim() ?: 'master'
-                sourceRepo = "https://github.com/${githubSlug}/edit/${githubBranch}/src/main/docs"
-                sourceDir = layout.projectDirectory.dir("src/main/docs")
-                resourcesDir = prepareDocsResources.flatMap(PrepareDocResourcesTask::getOutputDirectory)
-                propertiesFiles.from(rootProject.file("gradle.properties"))
-                asciidoc = true
-                properties.putAll([
+                t.sourceRepo = "https://github.com/${githubSlug}/edit/${githubBranch}/src/main/docs"
+                t.sourceDir = layout.projectDirectory.dir("src/main/docs")
+                t.resourcesDir = prepareDocsResources.flatMap(PrepareDocResourcesTask::getOutputDirectory)
+                t.propertiesFiles.from(rootProject.file("gradle.properties"))
+                t.asciidoc = true
+                if (lang != "") {
+                    t.language = lang
+                }
+                t.properties.putAll([
                         'safe': 'UNSAFE',
                         'source-highlighter': 'highlightjs',
                         'version': projectVersion,
@@ -134,7 +136,19 @@ abstract class MicronautDocsPlugin implements Plugin<Project> {
                         'springapi': 'https://docs.spring.io/spring/docs/current/javadoc-api/',
                         'kafka-version': kafkaVersion
                 ])
+                if (lang != "") {
+                    t.properties.put('default-language', lang)
+                }
             }
+
+            // The empty language is the guide for all languages.
+            def langs = [""] + LanguageSnippetMacro.LANGS
+            def publishGuideByLang = langs.collectEntries { lang ->
+                [(lang): tasks.register("publishGuide${lang.capitalize()}", PublishGuideTask) {
+                    configureGuideTask(it as PublishGuideTask, lang)
+                }]
+            }
+            def publishGuide = publishGuideByLang[""]
 
             def mergeConfigurationReference = tasks.register('mergeConfigurationReference', MergeConfigurationReferenceTask) { task ->
                 inputFiles.from(incomingConfigProps)
@@ -149,6 +163,8 @@ abstract class MicronautDocsPlugin implements Plugin<Project> {
                 pageTemplate.set(publishGuide.map { it.resourcesDir.file("style/page.html").get() })
             }
 
+            // TODO: For now, we don't include language specific guides into the final assembly. Language specific guides
+            //       are an experimental feature that needs more work before becoming the standard way docs are shipped.
             def assembleDocs = tasks.register("assembleDocs", Sync) {
                 description = "Assembles the documentation"
                 destinationDir = layout.buildDirectory.dir("working/04-assembled-docs").get().asFile

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/docs/PublishGuideTask.java
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/docs/PublishGuideTask.java
@@ -124,19 +124,6 @@ public abstract class PublishGuideTask extends DefaultTask {
         publisher.setStyle(getResourcesDir().dir("style").get().getAsFile());
         publisher.setVersion(String.valueOf(props.get("grails.version")));
 
-        // Override doc.properties properties with their language-specific counterparts (if
-        // those are defined). You just need to add entries like es.title or pt_PT.subtitle.
-        if (getLanguage().isPresent()) {
-            String language = getLanguage().get();
-            int pos = language.length() + 1;
-            props.entrySet().stream()
-                    .filter(e -> String.valueOf(e.getKey()).startsWith(language + "."))
-                    .forEach(e -> {
-                        String key = String.valueOf(e.getKey()).substring(pos);
-                        props.put(key, e.getValue());
-                    });
-        }
-
         // Aliases and other doc.properties entries are passed in as engine properties. This
         // is how the doc title, subtitle, etc. are set.
         publisher.setEngineProperties(props);

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/DocPublisher.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/DocPublisher.groovy
@@ -68,7 +68,7 @@ class DocPublisher {
 
     FileOperations fileOperations
 
-    /** The language we're generating for (gets its own sub-directory). Defaults to '' */
+    /** The programming language we're generating for (gets its own sub-directory). Defaults to '' */
     String language = ""
     /** The encoding to use (default is UTF-8) */
     String encoding = "UTF-8"
@@ -224,7 +224,8 @@ class DocPublisher {
         File yamlTocFile = null
         if (language) {
             yamlTocFile = new File(guideSrcDir, "toc-${language}.yml")
-        } else if (yamlTocFile == null || !yamlTocFile.exists()) {
+        }
+        if (yamlTocFile == null || !yamlTocFile.exists()) {
             yamlTocFile = new File(guideSrcDir, TOC_FILENAME)
         }
         def guide

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/DocPublisher.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/DocPublisher.groovy
@@ -31,6 +31,7 @@ import org.radeox.engine.context.BaseInitialRenderContext
 import org.radeox.engine.context.BaseRenderContext
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
+
 /**
  * Coordinated the DocEngine the produce documentation based on the gdoc format.
  *
@@ -64,7 +65,7 @@ class DocPublisher {
      * The properties fie to populate the engine properties from
      */
     File propertiesFile
-    
+
     FileOperations fileOperations
 
     /** The language we're generating for (gets its own sub-directory). Defaults to '' */
@@ -210,16 +211,22 @@ class DocPublisher {
 
 
         // Build the table of contents as a tree of nodes. We currently support
-        // two strategies for this:
+        // three strategies for this:
         //
-        //  1. From a toc.yml file
-        //  2. From the gdoc filenames
+        //  1. From a toc-<lang>.yml file if it exists otherwise...
+        //  2. From a toc.yml file
+        //  3. From the gdoc filenames
         //
-        // The first strategy is used if the TOC file exists, otherwise we call
+        // The first two strategies are used if the TOC files exist, otherwise we call
         // back to the old way of doing it, which means putting the section
         // numbers in the gdoc filenames.
         def guideSrcDir = new File(src, "guide")
-        def yamlTocFile = new File(guideSrcDir, TOC_FILENAME)
+        File yamlTocFile = null
+        if (language) {
+            yamlTocFile = new File(guideSrcDir, "toc-${language}.yml")
+        } else if (yamlTocFile == null || !yamlTocFile.exists()) {
+            yamlTocFile = new File(guideSrcDir, TOC_FILENAME)
+        }
         def guide
         def ext = asciidoc ? ".adoc" : ".gdoc"
         if (yamlTocFile.exists()) {
@@ -275,6 +282,18 @@ class DocPublisher {
                     sections: f.listFiles().findAll { it.name.endsWith(ext) }.sort())
         }
 
+        def extraCss = ""
+        for (final def l in LanguageSnippetMacro.LANGS) {
+            if (language) {
+                // Make everything invisible except the target language.
+                def display = l != language ? "none" : "block"
+                extraCss += ".lang-$l { display: $display }; "
+            } else {
+                // Make everything visible.
+                extraCss += ".lang-$l { display: block }; "
+            }
+        }
+
         def pathToRoot = ".."
         Map vars = new LinkedHashMap(engineProperties)
         vars.putAll(
@@ -298,6 +317,7 @@ class DocPublisher {
             next: null,
             legacyLinks: legacyLinks,
             sourceRepo: sourceRepo,
+            extraCss: extraCss
         )
 
         if(engine instanceof AsciiDocEngine) {
@@ -513,7 +533,10 @@ class DocPublisher {
 
     protected void initialize() {
         if (language) {
-            src = new File(src, language)
+            File langDir = new File(src, language)
+            if (langDir.exists()) {
+                src = langDir
+            }
         }
         if (!apiDir) {
             apiDir = target

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
@@ -7,14 +7,14 @@ import org.asciidoctor.SafeMode
 import org.asciidoctor.ast.StructuralNode
 import org.asciidoctor.extension.BlockMacroProcessor
 
-class LanguageSnippetMacro extends BlockMacroProcessor implements ValueAtAttributes {
+public class LanguageSnippetMacro extends BlockMacroProcessor implements ValueAtAttributes {
     final Asciidoctor asciidoctor
 
     private static final String LANG_JAVA = 'java'
     private static final String LANG_GROOVY = 'groovy'
     private static final String LANG_KOTLIN = 'kotlin'
     private static final String LANG_PYTHON = 'python'
-    private static final List<String> LANGS = [LANG_JAVA, LANG_PYTHON, LANG_KOTLIN, LANG_GROOVY]
+    public static final List<String> LANGS = [LANG_JAVA, LANG_PYTHON, LANG_KOTLIN, LANG_GROOVY]
     private static final String DEFAULT_KOTLIN_PROJECT = 'test-suite-kotlin'
     private static final String DEFAULT_PYTHON_PROJECT = 'test-suite-python'
     private static final String DEFAULT_JAVA_PROJECT = 'test-suite'
@@ -59,14 +59,24 @@ class LanguageSnippetMacro extends BlockMacroProcessor implements ValueAtAttribu
         String title = valueAtAttributes("title", attributes)
         StringBuilder content = new StringBuilder()
 
+        // Determine the target guide language (if any) from the Asciidoctor document attributes.
+        // MicronautDocsPlugin sets 'default-language' as an engine property when generating
+        // language-specific guides, and AsciiDocEngine forwards engine properties as document attributes.
+        String defaultLanguage = parent.document.getAttribute('default-language')
+
+        // If a specific target language is requested and it is one of the known code languages,
+        // only render that language, and do NOT use the multi-language-sample selector class.
+        List<String> languagesToRender = LANGS
+        if (defaultLanguage && LANGS.contains(defaultLanguage)) {
+            languagesToRender = [defaultLanguage]
+        }
+
         String[] files = target.split(",")
-        for (lang in LANGS) {
-            if (title != null) {
-                content << ".$title\n\n"
-            }
+        for (lang in languagesToRender) {
+            if (title != null) content << ".$title\n\n"
             String projectDir = projectDir(lang, attributes)
-            String ext 
-            
+            String ext
+
             if(lang == LANG_KOTLIN)
                 ext = 'kt'
             else if (lang == LANG_PYTHON)

--- a/micronaut-gradle-plugins/src/main/template/style/layout.html
+++ b/micronaut-gradle-plugins/src/main/template/style/layout.html
@@ -23,7 +23,9 @@
             document.body.className = classes.join(" ");
         }
     </script>
-
+    <style type="text/css">
+        ${extraCss}
+    </style>
 </head>
 
 <body class="body" id="docs" onload="addJsClass();" onhashchange="highlightMenu()">


### PR DESCRIPTION
This change adds new publishGuide{Lang} tasks that do the following:

1. Code snippet selectors are gone for multi-language snippets (unless the set of languages doesn't include that language).
2. `.lang-${lang}` CSS rules are added.
3. Language specific tables of content are used if available.

This allows you to customize the content for a language by hiding or showing pages or asciidoc blocks. Example:

```asciidoc
[.lang-kotlin.lang-java]
--
If you use Java or Kotlin, do blah....
--
```

That's invisible for other languages.

The resulting tasks aren't invoked by the rest of the docs build pipeline, so for now, this feature is experimental. Taking it through launch would involve rethinking the website design, probably adding links to switch between languages, and so on.