### PR TITLE
Upgrade Kotlin to 2.3.0 and Kotlin KSP to 2.3.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,8 +30,8 @@ groovy = "5.0.3"
 junit6 = "6.0.1"
 logback = "1.5.20"
 checkstyle = "12.1.0"
-kotlin = "2.2.21"
-kotlin-ksp = "2.2.21-2.0.4"
+kotlin = "2.3.0"
+kotlin-ksp = "2.3.4"
 
 [libraries]
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }


### PR DESCRIPTION
Updated Kotlin and Kotlin KSP versions to 2.3.0 and 2.3.4 respectively. [Core was already updated ](https://github.com/micronaut-projects/micronaut-core/pull/12318). 