### PR TITLE
Generate a Python module into JAR files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 .gradle
-build/
 out/
 .settings/
 .classpath
 .project
 .factorypath
+
+build/
+!**/src/main/**/io/micronaut/build
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ logback = "1.5.20"
 checkstyle = "12.1.0"
 kotlin = "2.3.0"
 kotlin-ksp = "2.3.4"
+pyinterfacegen = "25.1.0-SNAPSHOT"
 
 [libraries]
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
@@ -42,6 +43,7 @@ japicmp-plugin = { module = "me.champeau.gradle:japicmp-gradle-plugin", version.
 gradle-custom-userdata-plugin = { module = "com.gradle:common-custom-user-data-gradle-plugin", version.ref = "gradle-custom-userdata-plugin" }
 develocity-plugin = { module = "com.gradle:develocity-gradle-plugin", version.ref = "develocity-plugin" }
 gradle-github-actions-plugin = { module = "org.nosphere.gradle.github:gradle-github-actions-plugin", version.ref = "gradle-github-actions-plugin" }
+gradle-pyinterfacegen-plugin = { module = "org.graalvm.python.pyinterfacegen:org.graalvm.python.pyinterfacegen.gradle.plugin", version.ref = "pyinterfacegen" }
 grails-gdoc = { module = "org.grails:grails-gdoc-engine", version.ref = "grails-gdoc" }
 nexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexus-publish-plugin" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }

--- a/micronaut-gradle-plugins/build.gradle.kts
+++ b/micronaut-gradle-plugins/build.gradle.kts
@@ -3,6 +3,13 @@ plugins {
     id("groovy-gradle-plugin")
 }
 
+// FIXME: Remove this before merge.
+repositories {
+    mavenLocal()
+    mavenCentral()
+    gradlePluginPortal()
+}
+
 dependencies {
     constraints {
         implementation(libs.bundles.bouncycastle) {
@@ -30,6 +37,8 @@ dependencies {
 
     implementation(libs.tomlj)
     implementation(libs.maven.model.builder)
+
+    implementation(libs.gradle.pyinterfacegen.plugin)
 
     // We must differentiate the version that we use HERE to test the build plugins, which
     // should use a version of Spock which is compatible with what Gradle uses (Groovy 4)
@@ -87,6 +96,7 @@ micronautBuildPlugin {
     definePlugin("binary-compatibility-check", "io.micronaut.build.compat.MicronautBinaryCompatibilityPlugin")
     definePlugin("bom", "io.micronaut.build.MicronautBomPlugin")
     definePlugin("common", "io.micronaut.build.MicronautBuildCommonPlugin")
+    definePlugin("graalpy-bindings", "io.micronaut.build.graalpy.GraalPyModulePlugin")
     definePlugin("dependency-updates", "io.micronaut.build.MicronautDependencyUpdatesPlugin")
     definePlugin("develocity", "io.micronaut.build.MicronautDevelocityPlugin")
     definePlugin("docs", "io.micronaut.build.MicronautDocsPlugin")

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
@@ -2,6 +2,7 @@ package io.micronaut.build
 
 import groovy.transform.CompileStatic
 import io.micronaut.build.compat.MicronautBinaryCompatibilityPlugin
+import io.micronaut.build.graalpy.GraalPyModulePlugin
 import io.micronaut.build.info.MicronautModuleInfoPlugin
 import io.micronaut.build.pom.PomCheckerUtils
 import org.gradle.api.Plugin
@@ -14,6 +15,7 @@ import org.gradle.api.tasks.testing.Test
  *  - with dependency updates plugin
  *  - published on a Maven repository
  *  - with JUnit platform testing
+ *  - with Python type information generation
  */
 @CompileStatic
 class MicronautBaseModulePlugin implements Plugin<Project> {
@@ -26,6 +28,7 @@ class MicronautBaseModulePlugin implements Plugin<Project> {
         project.pluginManager.apply(MicronautBinaryCompatibilityPlugin)
         project.pluginManager.apply(SonatypeConfigurationPlugin)
         project.pluginManager.apply(MicronautModuleInfoPlugin)
+        project.pluginManager.apply(GraalPyModulePlugin)
         configureJUnit(project)
         assertSettingsPluginApplied(project)
         project.pluginManager.withPlugin("maven-publish") {

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -28,7 +28,6 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
         def micronautBuild = project.extensions.findByType(MicronautBuildExtension)
         configureJavaPlugin(project, micronautBuild)
         configureDependencies(project, micronautBuild)
-        project.pluginManager.apply(GraalPyModulePlugin)
         configureTasks(project)
         configureIdeaPlugin(project)
         configureLicensePlugin(project)

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBuildCommonPlugin.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.build
 
 import com.diffplug.gradle.spotless.SpotlessTask
+import io.micronaut.build.graalpy.GraalPyModulePlugin
 import io.micronaut.build.utils.DefaultVersions
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -27,6 +28,7 @@ class MicronautBuildCommonPlugin implements Plugin<Project> {
         def micronautBuild = project.extensions.findByType(MicronautBuildExtension)
         configureJavaPlugin(project, micronautBuild)
         configureDependencies(project, micronautBuild)
+        project.pluginManager.apply(GraalPyModulePlugin)
         configureTasks(project)
         configureIdeaPlugin(project)
         configureLicensePlugin(project)

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
@@ -8,6 +8,7 @@ import io.micronaut.build.docs.PublishGuideTask
 import io.micronaut.build.docs.ValidateAsciidocOutputTask
 import io.micronaut.build.docs.props.MergeConfigurationReferenceTask
 import io.micronaut.build.docs.props.PublishConfigurationReferenceTask
+import io.micronaut.build.graalpy.GraalPyModulePlugin
 import io.micronaut.build.utils.GitHubApiService
 import io.micronaut.docs.LanguageSnippetMacro
 import org.gradle.api.Plugin

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/graalpy/GraalPyModulePlugin.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/graalpy/GraalPyModulePlugin.java
@@ -1,0 +1,153 @@
+package io.micronaut.build.graalpy;
+
+import org.graalvm.python.pyinterfacegen.TypeCheckPyiTask;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.Directory;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.api.tasks.javadoc.Javadoc;
+import org.gradle.external.javadoc.StandardJavadocDocletOptions;
+import org.jspecify.annotations.NonNull;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Generates a GraalPy-oriented Python module (.pyi stubs + runtime __init__.py)
+ * from project Java sources using the j2pyi Javadoc doclet, and packages the
+ * results into the published JAR under META-INF/graalpy-module.
+ * <p>
+ * This avoids introducing a new external Gradle plugin and instead reuses the
+ * existing per-project Javadoc flow with a custom doclet.
+ */
+public class GraalPyModulePlugin implements Plugin<Project> {
+    // Default coordinate for the doclet; can be overridden via project property 'graalPyDocletCoordinate'
+    private static final String DEFAULT_DOCLET_COORD = "org.graalvm.python:j2pyi-doclet:25.1.0-SNAPSHOT";
+    // Doclet class
+    private static final String DOCLET_CLASS = "org.graalvm.python.pyinterfacegen.J2PyiDoclet";
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(JavaPlugin.class);
+
+        // Configuration that provides the j2pyi doclet artifact.
+        Configuration docletConf = project.getConfigurations().maybeCreate("graalPyDoclet");
+        docletConf.setCanBeConsumed(false);
+        docletConf.setCanBeResolved(true);
+        docletConf.defaultDependencies(deps -> {
+            String coord = (String) project.findProperty("graalPyDocletCoordinate");
+            if (coord == null || coord.isBlank()) {
+                coord = DEFAULT_DOCLET_COORD;
+            }
+            deps.add(project.getDependencies().create(coord));
+        });
+
+        // FIXME: Take out maven local once pyinterfacegen is published to Maven Central.
+        project.getRepositories().mavenLocal();
+        project.getRepositories().mavenCentral();
+
+        // Register a dedicated Javadoc run using the custom doclet.
+        var generatePyi = project.getTasks().register(
+                "generateGraalPyModule",
+                Javadoc.class,
+                javadoc -> configureGraalPyTask(project, javadoc, docletConf)
+        );
+
+        var typeCheckGraalPyModule = project.getTasks().register(
+                "typeCheckGraalPyModule",
+                TypeCheckPyiTask.class,
+                (TypeCheckPyiTask typeCheckTask) -> {
+                    typeCheckTask.setGroup("Documentation");
+                    typeCheckTask.setDescription("Type check the generated Python module for conversion errors.");
+                    typeCheckTask.getModuleDir().set(getDestinationDir(project));
+                    typeCheckTask.dependsOn(generatePyi);
+                }
+        );
+
+        // Package the generated module into the main jar
+        project.getTasks().withType(Jar.class).configureEach(jar -> {
+            jar.dependsOn(generatePyi);
+            jar.from(generatePyi.map(Javadoc::getDestinationDir), spec ->
+                spec.into("META-INF/graalpy-module")
+            );
+        });
+    }
+
+    private static void configureGraalPyTask(Project project, Javadoc javadoc, Configuration docletConf) {
+        javadoc.setGroup("Documentation");
+        javadoc.setDescription("Generate a Python module (.pyi + runtime) for GraalPy interop using the j2pyi doclet");
+        // Destination is a unified module root produced by the doclet
+        javadoc.setDestinationDir(getDestinationDir(project).get().getAsFile());
+
+        // Use main source set by default.
+        //
+        // IMPORTANT: in mixed-language modules (e.g. Kotlin), Javadoc needs the compiled classes
+        // of those other languages on its classpath, otherwise it will fail to resolve types.
+        // Micronaut's build adds such outputs to the regular `javadoc` task; mirror that behavior
+        // here so the generated GraalPy module isn't empty in Kotlin-heavy modules.
+        project.getPlugins().withType(JavaPlugin.class, unused -> {
+            JavaPluginExtension javaExt = project.getExtensions().getByType(JavaPluginExtension.class);
+            SourceSet main = javaExt.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+
+            // If we put compiled classes and processed resources on the Javadoc classpath, we must ensure
+            // those outputs are built first (Gradle 9+ validates implicit dependencies).
+            javadoc.dependsOn(project.getTasks().named(main.getClassesTaskName()));
+            javadoc.dependsOn(project.getTasks().named(main.getProcessResourcesTaskName()));
+
+            if (javadoc.getSource().isEmpty()) {
+                javadoc.setSource(main.getAllJava().matching(p -> p.include("**/*.java")));
+            }
+
+            if (javadoc.getClasspath().isEmpty()) {
+                Set<File> cp = new LinkedHashSet<>();
+                cp.addAll(main.getCompileClasspath().getFiles());
+                cp.addAll(main.getOutput().getClassesDirs().getFiles());
+                File resourcesDir = main.getOutput().getResourcesDir();
+                if (resourcesDir != null) {
+                    cp.add(resourcesDir);
+                }
+                javadoc.setClasspath(project.files(cp));
+            }
+        });
+
+        StandardJavadocDocletOptions opts = (StandardJavadocDocletOptions) javadoc.getOptions();
+        opts.setDoclet(DOCLET_CLASS);
+
+        // Resolve doclet jars lazily and attach both to execution and cache fingerprint
+        // StandardJavadocDocletOptions#setDocletpath expects a List<File>, so resolve the configuration
+        opts.setDocletpath(new java.util.ArrayList<>(docletConf.resolve()));
+
+        // Pass module metadata: module name is the Gradle project name, version uses the Gradle project version
+        opts.addStringOption("Xj2pyi-moduleName", project.getName());
+        String version = String.valueOf(project.getVersion());
+        if (version != null && !"unspecified".equalsIgnoreCase(version)) {
+            opts.addStringOption("Xj2pyi-moduleVersion", version);
+        }
+
+        // Keep Javadoc quiet; unresolved bits are handled by the doclet
+        opts.addBooleanOption("quiet", true);
+        // Ensure JDK 21 javadoc doesn't receive unsupported -notimestamp
+        opts.setNoTimestamp(false);
+
+        // Optional package mapping: configure with -PgraalPyPackageMap=com.example=example,com.foo=foo
+        Object pkgMap = project.findProperty("graalPyPackageMap");
+        if (pkgMap instanceof String s && !s.isBlank()) {
+            opts.addStringOption("Xj2pyi-packageMap", s);
+        }
+
+        // Only treat Micronaut types as typed. Everything else is emitted as dynamic/untyped.
+        // Map Java package 'io.micronaut.*' to 'micronaut.*' in Python to avoid conflict with stdlib 'io'.
+        opts.addStringOption("Xj2pyi-packageMap", "io.micronaut=micronaut");
+        opts.addStringOption("Xj2pyi-assumedTypedPackageGlobs", "io.micronaut.**");
+    }
+
+    private static @NonNull Provider<Directory> getDestinationDir(Project project) {
+        return project.getLayout().getBuildDirectory().dir("graalpy-module/" + project.getName());
+    }
+}


### PR DESCRIPTION
This PR adds usage of the new j2pyi tool in https://github.com/oracle/graalpy-extensions/tree/main/pyinterfacegen to Micronaut Build such that projects get a Python module containing .pyi stubs for GraalPy included into the JAR.

It's not ready to merge yet because the j2pyi tool needs to be released to Maven Central first, and we may need to do more work on the bindings generation to make them high quality enough.

The idea is that some kind of tool can take the Python module out of the JARs and merge them together into a venv.

# Testing

I tested `micronaut-sql` with this new set of plugins locally and it worked. I haven't tested any other module.