### PR TITLE
Fix htmlSanityCheck 2.x jsoup classpath conflict

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 asciidoctorj = "3.0.0"
+jsoup = "1.18.3"
 commons-lang3 = "3.18.0"
 commons-text = "1.14.0"
 japicmp-plugin = "0.4.6"
@@ -35,6 +36,7 @@ kotlin-ksp = "2.3.4"
 
 [libraries]
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }

--- a/micronaut-gradle-plugins/build.gradle.kts
+++ b/micronaut-gradle-plugins/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(libs.snakeyaml)
     implementation(libs.grails.gdoc)
     implementation(libs.asciidoctorj)
+    implementation(libs.jsoup)
     implementation(libs.spotless.plugin)
     implementation(libs.testlogger.plugin)
     implementation(libs.nexus.publish.plugin)


### PR DESCRIPTION
## Summary
- add an explicit `org.jsoup:jsoup:1.18.3` version in the Micronaut Build version catalog
- include `libs.jsoup` in `micronaut-gradle-plugins` so the shared settings plugin classpath does not shadow htmlSanityCheck 2.x with jsoup 1.15.3
- unblock Micronaut Core docs html sanity checks from failing with `NoSuchMethodError: org.jsoup.nodes.Element.attribute(String)`

## Verification
- `./gradlew :micronaut-gradle-plugins:compileGroovy :micronaut-gradle-plugins:test --stacktrace`
- `./gradlew :micronaut-gradle-plugins:compileGroovy :micronaut-gradle-plugins:test -q`
- Cross-check in micronaut-core with temporary `pluginManagement { includeBuild("../micronaut-build") }`: htmlSanityCheck loads jsoup 1.18.3 and no longer throws the NoSuchMethodError

Fixes micronaut-projects/micronaut-core#12181