### PR TITLE
Add support for nullaway plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .gradle
-/build/
+build/
 out/
 .settings/
 .classpath

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .gradle
-build/
+/build/
 out/
 .settings/
 .classpath

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ maven-model-builder = "3.9.11"
 includegit = "0.3.0"
 sonatype-scan = "3.0.0"
 errorprone = "4.3.0"
+error_prone_core = "2.45.0"
 bouncycastle = "1.82"
 micronaut-docs = "3.0.0"
 micronaut-test = "5.0.0-M5"
@@ -34,6 +35,7 @@ logback = "1.5.20"
 checkstyle = "12.1.0"
 kotlin = "2.3.0"
 kotlin-ksp = "2.3.6"
+nullaway = "0.12.15"
 
 [libraries]
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
@@ -79,6 +81,9 @@ checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checks
 kotlin-jvm-plugin = { module = "org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin", version.ref = "kotlin" }
 kotlin-kapt-plugin = { module = "org.jetbrains.kotlin.kapt:org.jetbrains.kotlin.kapt.gradle.plugin", version.ref = "kotlin" }
 kotlin-ksp-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "kotlin-ksp" }
+gradle-errorprone = { module = "net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin", version.ref = "errorprone" }
+error-prone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "error_prone_core" }
+nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
 
 [bundles]
 bouncycastle = ["bc-prov", "bc-pkix"]

--- a/micronaut-gradle-plugins/build.gradle.kts
+++ b/micronaut-gradle-plugins/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.sonatype.scan.plugin) {
         exclude(group = "org.codehaus.groovy")
     }
+    implementation(libs.gradle.errorprone)
 
     implementation(libs.tomlj)
     implementation(libs.maven.model.builder)
@@ -81,6 +82,8 @@ micronautBuildPlugin {
     versionsMap.put("junit6", libs.versions.junit6)
     versionsMap.put("checkstyle", libs.versions.checkstyle)
     versionsMap.put("logback", libs.versions.logback)
+    versionsMap.put("nullaway", libs.versions.nullaway)
+    versionsMap.put("error_prone_core", libs.versions.error.prone.core)
 
     // Project plugins
     definePlugin("aot-module", "io.micronaut.build.aot.MicronautAotModulePlugin")
@@ -95,6 +98,7 @@ micronautBuildPlugin {
     definePlugin("java-base", "io.micronaut.build.MicronautBuildJavaBasePlugin")
     definePlugin("kotlin-base", "io.micronaut.build.MicronautBuildKotlinBasePlugin")
     definePlugin("module", "io.micronaut.build.MicronautModulePlugin")
+    definePlugin("nullaway", "io.micronaut.build.MicronautNullAwayPlugin")
     definePlugin("parent", "io.micronaut.build.MicronautParentPlugin")
     definePlugin("parent-publishing", "io.micronaut.build.MicronautParentPublishingPlugin")
     definePlugin("publishing", "io.micronaut.build.MicronautPublishingPlugin")

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
@@ -2,11 +2,15 @@ package io.micronaut.build.nullaway
 
 import org.gradle.testkit.runner.GradleRunner
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import java.nio.file.Files
 import java.nio.file.Path
 
 class MicronautNullAwayFunctionalTest extends Specification {
+
+    @TempDir
+    Path projectDir
 
     private static final String BUILD_SCRIPT = '''
         import io.micronaut.build.utils.DefaultVersions
@@ -65,7 +69,6 @@ class MicronautNullAwayFunctionalTest extends Specification {
 
     void "nullaway plugin configures default checks and dependencies"() {
         given:
-        Path projectDir = Files.createTempDirectory("nullaway-default")
         Files.writeString(projectDir.resolve("settings.gradle"), "rootProject.name = 'nullaway-default'")
         Files.writeString(projectDir.resolve("gradle.properties"), "projectVersion=1.0.0\ntitle=Demo")
         Files.writeString(projectDir.resolve("build.gradle"), BUILD_SCRIPT)
@@ -76,14 +79,10 @@ class MicronautNullAwayFunctionalTest extends Specification {
                 .withPluginClasspath()
                 .withArguments("verifyNullAway")
                 .build()
-
-        cleanup:
-        projectDir?.toFile()?.deleteDir()
     }
 
     void "nullaway plugin disables NullAway for tck projects"() {
         given:
-        Path projectDir = Files.createTempDirectory("nullaway-tck")
         Files.writeString(projectDir.resolve("settings.gradle"), "rootProject.name = 'demo-tck'")
         Files.writeString(projectDir.resolve("gradle.properties"), "projectVersion=1.0.0\ntitle=Demo")
         Files.writeString(projectDir.resolve("build.gradle"), TCK_BUILD_SCRIPT)
@@ -94,8 +93,5 @@ class MicronautNullAwayFunctionalTest extends Specification {
                 .withPluginClasspath()
                 .withArguments("verifyTckNullAway")
                 .build()
-
-        cleanup:
-        projectDir?.toFile()?.deleteDir()
     }
 }

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
@@ -1,0 +1,93 @@
+    package io.micronaut.build.nullaway
+
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class MicronautNullAwayFunctionalTest extends Specification {
+
+    private static final String BUILD_SCRIPT = '''
+        import io.micronaut.build.utils.DefaultVersions
+        import net.ltgt.gradle.errorprone.CheckSeverity
+        import net.ltgt.gradle.errorprone.ErrorProneOptionsKt
+
+        plugins {
+            id("io.micronaut.build.internal.base-module")
+        }
+
+        tasks.register("verifyNullAway") {
+            doLast {
+                def compileJava = tasks.named("compileJava").get()
+                def options = ErrorProneOptionsKt.getErrorprone(compileJava.options)
+                assert options.checks.get()["NullAway"] == CheckSeverity.ERROR
+                assert options.checks.get()["MissingOverride"] == CheckSeverity.ERROR
+                assert options.checkOptions.get()["NullAway:AnnotatedPackages"] == "io.micronaut"
+
+                def compileTestJava = tasks.named("compileTestJava").get()
+                def testOptions = ErrorProneOptionsKt.getErrorprone(compileTestJava.options)
+                assert testOptions.checks.get()["NullAway"] == CheckSeverity.OFF
+                assert testOptions.checks.get()["MissingOverride"] == CheckSeverity.ERROR
+
+                def deps = configurations.errorprone.dependencies.collect { "${it.group}:${it.name}:${it.version}" } as Set
+                assert deps.contains("com.uber.nullaway:nullaway:${DefaultVersions.NULLAWAY_VERSION}")
+                assert deps.contains("com.google.errorprone:error_prone_core:${DefaultVersions.ERROR_PRONE_CORE_VERSION}")
+            }
+        }
+    '''
+
+    private static final String TCK_BUILD_SCRIPT = '''
+        import net.ltgt.gradle.errorprone.CheckSeverity
+        import net.ltgt.gradle.errorprone.ErrorProneOptionsKt
+
+        plugins {
+            id("io.micronaut.build.internal.base-module")
+        }
+
+        tasks.register("verifyTckNullAway") {
+            doLast {
+                def compileJava = tasks.named("compileJava").get()
+                def options = ErrorProneOptionsKt.getErrorprone(compileJava.options)
+                assert options.checks.get()["NullAway"] == CheckSeverity.OFF
+                assert options.checks.get()["MissingOverride"] == CheckSeverity.ERROR
+            }
+        }
+    '''
+
+    void "nullaway plugin configures default checks and dependencies"() {
+        given:
+        Path projectDir = Files.createTempDirectory("nullaway-default")
+        Files.writeString(projectDir.resolve("settings.gradle"), "rootProject.name = 'nullaway-default'")
+        Files.writeString(projectDir.resolve("gradle.properties"), "projectVersion=1.0.0\ntitle=Demo")
+        Files.writeString(projectDir.resolve("build.gradle"), BUILD_SCRIPT)
+
+        expect:
+        GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withPluginClasspath()
+                .withArguments("verifyNullAway")
+                .build()
+
+        cleanup:
+        projectDir?.toFile()?.deleteDir()
+    }
+
+    void "nullaway plugin disables NullAway for tck projects"() {
+        given:
+        Path projectDir = Files.createTempDirectory("nullaway-tck")
+        Files.writeString(projectDir.resolve("settings.gradle"), "rootProject.name = 'demo-tck'")
+        Files.writeString(projectDir.resolve("gradle.properties"), "projectVersion=1.0.0\ntitle=Demo")
+        Files.writeString(projectDir.resolve("build.gradle"), TCK_BUILD_SCRIPT)
+
+        expect:
+        GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withPluginClasspath()
+                .withArguments("verifyTckNullAway")
+                .build()
+
+        cleanup:
+        projectDir?.toFile()?.deleteDir()
+    }
+}

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
@@ -1,16 +1,8 @@
 package io.micronaut.build.nullaway
 
-import org.gradle.testkit.runner.GradleRunner
-import spock.lang.Specification
-import spock.lang.TempDir
+import io.micronaut.build.AbstractFunctionalTest
 
-import java.nio.file.Files
-import java.nio.file.Path
-
-class MicronautNullAwayFunctionalTest extends Specification {
-
-    @TempDir
-    Path projectDir
+class MicronautNullAwayFunctionalTest extends AbstractFunctionalTest {
 
     private static final String BUILD_SCRIPT = '''
         import io.micronaut.build.utils.DefaultVersions
@@ -69,29 +61,27 @@ class MicronautNullAwayFunctionalTest extends Specification {
 
     void "nullaway plugin configures default checks and dependencies"() {
         given:
-        Files.writeString(projectDir.resolve("settings.gradle"), "rootProject.name = 'nullaway-default'")
-        Files.writeString(projectDir.resolve("gradle.properties"), "projectVersion=1.0.0\ntitle=Demo")
-        Files.writeString(projectDir.resolve("build.gradle"), BUILD_SCRIPT)
+        settingsFile.text = "rootProject.name = 'nullaway-default'"
+        gradlePropertiesFile.text = "projectVersion=1.0.0\ntitle=Demo"
+        buildFile.text = BUILD_SCRIPT
 
-        expect:
-        GradleRunner.create()
-                .withProjectDir(projectDir.toFile())
-                .withPluginClasspath()
-                .withArguments("verifyNullAway")
-                .build()
+        when:
+        run "verifyNullAway"
+
+        then:
+        noExceptionThrown()
     }
 
     void "nullaway plugin disables NullAway for tck projects"() {
         given:
-        Files.writeString(projectDir.resolve("settings.gradle"), "rootProject.name = 'demo-tck'")
-        Files.writeString(projectDir.resolve("gradle.properties"), "projectVersion=1.0.0\ntitle=Demo")
-        Files.writeString(projectDir.resolve("build.gradle"), TCK_BUILD_SCRIPT)
+        settingsFile.text = "rootProject.name = 'demo-tck'"
+        gradlePropertiesFile.text = "projectVersion=1.0.0\ntitle=Demo"
+        buildFile.text = TCK_BUILD_SCRIPT
 
-        expect:
-        GradleRunner.create()
-                .withProjectDir(projectDir.toFile())
-                .withPluginClasspath()
-                .withArguments("verifyTckNullAway")
-                .build()
+        when:
+        run "verifyTckNullAway"
+
+        then:
+        noExceptionThrown()
     }
 }

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
@@ -17,6 +17,10 @@ class MicronautNullAwayFunctionalTest extends Specification {
             id("io.micronaut.build.internal.base-module")
         }
 
+        micronautBuild {
+            enableProcessing.set(false)
+        }
+
         tasks.register("verifyNullAway") {
             doLast {
                 def compileJava = tasks.named("compileJava").get()
@@ -43,6 +47,10 @@ class MicronautNullAwayFunctionalTest extends Specification {
 
         plugins {
             id("io.micronaut.build.internal.base-module")
+        }
+
+        micronautBuild {
+            enableProcessing.set(false)
         }
 
         tasks.register("verifyTckNullAway") {

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
@@ -1,4 +1,4 @@
-    package io.micronaut.build.nullaway
+package io.micronaut.build.nullaway
 
 import org.gradle.testkit.runner.GradleRunner
 import spock.lang.Specification

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
@@ -26,6 +26,7 @@ class MicronautBaseModulePlugin implements Plugin<Project> {
         project.pluginManager.apply(MicronautBinaryCompatibilityPlugin)
         project.pluginManager.apply(SonatypeConfigurationPlugin)
         project.pluginManager.apply(MicronautModuleInfoPlugin)
+        project.pluginManager.apply(MicronautNullAwayPlugin)
         configureJUnit(project)
         assertSettingsPluginApplied(project)
         project.pluginManager.withPlugin("maven-publish") {

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautNullAwayPlugin.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautNullAwayPlugin.groovy
@@ -1,0 +1,60 @@
+package io.micronaut.build
+
+import groovy.transform.CompileStatic
+import io.micronaut.build.nullaway.MicronautNullAwayExtension
+import io.micronaut.build.utils.DefaultVersions
+import net.ltgt.gradle.errorprone.CheckSeverity
+import net.ltgt.gradle.errorprone.ErrorProneOptions
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.compile.JavaCompile
+
+import java.util.Collections
+import java.util.Locale
+
+import static io.micronaut.build.utils.VersionHandling.versionProviderOrDefault
+import static net.ltgt.gradle.errorprone.ErrorProneOptionsKt.errorprone
+
+@CompileStatic
+class MicronautNullAwayPlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        project.pluginManager.apply('io.micronaut.build.internal.base')
+        project.pluginManager.apply('net.ltgt.errorprone')
+
+        MicronautNullAwayExtension extension = project.extensions.create('micronautNullAway', MicronautNullAwayExtension)
+
+        project.dependencies.addProvider('errorprone',
+                versionProviderOrDefault(project, 'nullaway', DefaultVersions.NULLAWAY_VERSION)
+                        .map { version -> "com.uber.nullaway:nullaway:$version" })
+        project.dependencies.addProvider('errorprone',
+                versionProviderOrDefault(project, 'error_prone_core', DefaultVersions.ERROR_PRONE_CORE_VERSION)
+                        .map { version -> "com.google.errorprone:error_prone_core:$version" })
+
+        project.tasks.withType(JavaCompile).configureEach { JavaCompile compile ->
+            errorprone(compile.options) { ErrorProneOptions options ->
+                extension.checks.getOrElse(Collections.<String, CheckSeverity>emptyMap()).each { String check, CheckSeverity severity ->
+                    options.check(check, severity)
+                }
+                extension.options.getOrElse(Collections.<String, String>emptyMap()).each { String key, String value ->
+                    options.option(key, value)
+                }
+                extension.additionalActions.each { action -> action.execute(options) }
+            }
+            boolean disableForTask = extension.disableOnTaskNameContains.getOrElse(Collections.<String>emptySet()).any { String needle ->
+                compile.name.toLowerCase(Locale.US).contains(needle.toLowerCase(Locale.US))
+            }
+            boolean disableForProject = extension.disableOnProjectNameContains.getOrElse(Collections.<String>emptySet()).any { String needle ->
+                project.name.toLowerCase(Locale.US).contains(needle.toLowerCase(Locale.US))
+            }
+            if (disableForTask || disableForProject) {
+                errorprone(compile.options) { ErrorProneOptions options ->
+                    extension.disabledChecks.getOrElse(Collections.<String>emptySet()).each { String check ->
+                        options.disable(check)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/nullaway/MicronautNullAwayExtension.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/nullaway/MicronautNullAwayExtension.java
@@ -1,0 +1,53 @@
+package io.micronaut.build.nullaway;
+
+import net.ltgt.gradle.errorprone.CheckSeverity;
+import net.ltgt.gradle.errorprone.ErrorProneOptions;
+import org.gradle.api.Action;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.SetProperty;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Exposes NullAway configuration knobs while providing Micronaut defaults.
+ */
+public abstract class MicronautNullAwayExtension {
+
+    private final List<Action<? super ErrorProneOptions>> additionalActions = new ArrayList<>();
+
+    @Inject
+    public MicronautNullAwayExtension() {
+        getChecks().put("NullAway", CheckSeverity.ERROR);
+        getChecks().put("MissingOverride", CheckSeverity.ERROR);
+        getOptions().put("NullAway:AnnotatedPackages", "io.micronaut");
+        getDisableOnTaskNameContains().add("test");
+        getDisableOnProjectNameContains().add("tck");
+        getDisabledChecks().add("NullAway");
+    }
+
+    public abstract MapProperty<String, CheckSeverity> getChecks();
+
+    public abstract MapProperty<String, String> getOptions();
+
+    public abstract SetProperty<String> getDisableOnTaskNameContains();
+
+    public abstract SetProperty<String> getDisableOnProjectNameContains();
+
+    public abstract SetProperty<String> getDisabledChecks();
+
+    public List<Action<? super ErrorProneOptions>> getAdditionalActions() {
+        return Collections.unmodifiableList(additionalActions);
+    }
+
+    /**
+     * Adds additional configuration applied after defaults.
+     *
+     * @param action additional configuration action
+     */
+    public void configure(Action<? super ErrorProneOptions> action) {
+        additionalActions.add(action);
+    }
+}


### PR DESCRIPTION
To replace this in core:
```
plugins {
    id "io.micronaut.build.internal.base"
    id 'net.ltgt.errorprone'
}

dependencies {
    errorprone libs.nullaway
    errorprone libs.error.prone.core
}

tasks.withType(JavaCompile).configureEach {
    options.errorprone {
        check("NullAway", CheckSeverity.ERROR)
        check("MissingOverride", CheckSeverity.ERROR)
        option("NullAway:AnnotatedPackages", "io.micronaut")
    }
    // Disable NullAway on test code and TCK
    if (name.toLowerCase().contains("test") || project.name.contains("tck")) {
        options.errorprone {
            disable("NullAway")
        }
    }
}
```