### PR TITLE
Java 25 as default

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '21'
+        java-version: '25'
     - name: "🔧 Setup Gradle"
       uses: gradle/actions/setup-gradle@v4
     - name: Check plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           ref: ${{ github.head_ref }}
       - name: Set the current release version
         id: release_version

--- a/buildSrc/src/main/kotlin/io.micronaut.build.internal.gradle-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.micronaut.build.internal.gradle-plugin.gradle.kts
@@ -23,8 +23,8 @@ repositories {
 java {
     withJavadocJar()
     withSourcesJar()
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 tasks.withType<Test>().configureEach {

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
@@ -2,7 +2,7 @@ package io.micronaut.build
 
 class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
 
-    void "defaults to Java 21"() {
+    void "defaults to Java 25"() {
         given:
         withSample("test-micronaut-module")
 
@@ -19,7 +19,7 @@ class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
         run 'printJavaVersion'
 
         then:
-        outputContains "Java version: 21"
+        outputContains "Java version: 25"
     }
 
     void "test java defaults to current JDK"() {

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -16,7 +16,7 @@ import javax.inject.Inject;
 public abstract class MicronautBuildExtension {
 
   public static final String DEFAULT_DEPENDENCY_UPDATES_PATTERN = "(?i).+(-|\\.?)(b|M|RC|Dev)\\d?.*";
-  public static final int DEFAULT_JAVA_VERSION = 21;
+  public static final int DEFAULT_JAVA_VERSION = 25;
 
   private final BuildEnvironment environment;
 


### PR DESCRIPTION
Now I see this exception in every module which uses kotlin:

<img width="2526" height="1203" alt="изображение" src="https://github.com/user-attachments/assets/904ab8cc-a304-48bf-aaea-71ab148a4b8a" />

I'm not sure if this is the only issue with this plugin, but it's clear that Java version 21 is being pulled from here because version 25 is specified throughout my project.