### PR TITLE
Migrate tests to mockserver neolight

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ gradle-custom-userdata-plugin = "2.3"
 develocity-plugin = "4.2.2"
 gradle-github-actions-plugin = "1.4.0"
 grails-gdoc = "1.0.1"
-mockserver = "5.15.0"
+mockserver = "2.0.4"
 nexus-publish-plugin = "2.0.0"
 snakeyaml = "2.5"
 sonar-plugin = "6.3.1.5724"
@@ -46,8 +46,6 @@ develocity-plugin = { module = "com.gradle:develocity-gradle-plugin", version.re
 gradle-github-actions-plugin = { module = "org.nosphere.gradle.github:gradle-github-actions-plugin", version.ref = "gradle-github-actions-plugin" }
 grails-gdoc = { module = "org.grails:grails-gdoc-engine", version.ref = "grails-gdoc" }
 nexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexus-publish-plugin" }
-mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }
-mockserver-client = { module = "org.mock-server:mockserver-client-java", version.ref = "mockserver" }
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
 sonar-plugin = { module = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin", version.ref = "sonar-plugin" }
 spock-bom = { module = "org.spockframework:spock-bom", version.ref = "spock" }
@@ -66,7 +64,8 @@ micronaut-docs = { module = "io.micronaut.docs:micronaut-docs-asciidoc-config-pr
 micronaut-logging = { module = "io.micronaut.logging:micronaut-logging", version.ref = "micronaut-logging" }
 micronaut-test = { module = "io.micronaut.test:micronaut-test", version.ref = "micronaut-test" }
 groovy = { module = "org.codehaus.groovy:groovy-core", version.ref = "groovy" }
-
+mockserver-client = { module = "software.xdev.mockserver:client", version.ref = "mockserver" }
+mockserver-server = { module = "software.xdev.mockserver:server", version.ref = "mockserver" }
 
 junit6-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit6" }
 junit6-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit6" }

--- a/micronaut-gradle-plugins/build.gradle.kts
+++ b/micronaut-gradle-plugins/build.gradle.kts
@@ -50,9 +50,8 @@ dependencies {
 
     testImplementation(libs.typesafe.config)
 
-    testImplementation(libs.mockserver.netty)
+    testImplementation(libs.mockserver.server)
     testImplementation(libs.mockserver.client)
-
 }
 
 val docFilesJar = tasks.register<Jar>("docFilesJar") {

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/catalogs/VersionCatalogUpdateFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/catalogs/VersionCatalogUpdateFunctionalTest.groovy
@@ -16,42 +16,28 @@
 package io.micronaut.build.catalogs
 
 import io.micronaut.build.AbstractFunctionalTest
-import org.mockserver.configuration.Configuration
-import org.mockserver.integration.ClientAndServer
-import org.mockserver.logging.MockServerLogger
-import org.mockserver.mock.action.ExpectationResponseCallback
-import org.mockserver.model.HttpRequest
-import org.mockserver.model.HttpResponse
-import org.mockserver.model.MediaType
-import org.mockserver.socket.tls.KeyStoreFactory
+import software.xdev.mockserver.client.MockServerClient
+import software.xdev.mockserver.mock.action.ExpectationResponseCallback
+import software.xdev.mockserver.model.HttpRequest
+import software.xdev.mockserver.model.HttpResponse
+import software.xdev.mockserver.model.MediaType
+import software.xdev.mockserver.netty.MockServer
 import spock.lang.Shared
 
-import javax.net.ssl.HttpsURLConnection
-import javax.net.ssl.SSLSocketFactory
-
-import static org.mockserver.integration.ClientAndServer.startClientAndServer
-import static org.mockserver.model.HttpRequest.request
-import static org.mockserver.model.HttpResponse.notFoundResponse
-import static org.mockserver.model.HttpResponse.response
+import static software.xdev.mockserver.model.HttpRequest.request
+import static software.xdev.mockserver.model.HttpResponse.notFoundResponse
+import static software.xdev.mockserver.model.HttpResponse.response
 
 class VersionCatalogUpdateFunctionalTest extends AbstractFunctionalTest {
 
-    ClientAndServer repository
-
     @Shared
-    private SSLSocketFactory sslFactory
-
-    def setupSpec() {
-        sslFactory = HttpsURLConnection.getDefaultSSLSocketFactory()
-        HttpsURLConnection.setDefaultSSLSocketFactory(new KeyStoreFactory(new Configuration(), new MockServerLogger()).sslContext().socketFactory)
-    }
-
-    def cleanupSpec() {
-        HttpsURLConnection.setDefaultSSLSocketFactory(sslFactory)
-    }
+    private MockServer mockServer
+    @Shared
+    private MockServerClient repository
 
     def setup() {
-        repository = startClientAndServer()
+        mockServer = new MockServer()
+        repository = new MockServerClient("localhost", mockServer.localPort)
         buildFile << """
             plugins {
                 id 'io.micronaut.build.internal.version-catalog-updates'            
@@ -59,14 +45,16 @@ class VersionCatalogUpdateFunctionalTest extends AbstractFunctionalTest {
             
             repositories {
                 maven {
-                    url "https://localhost:${repository.port}"
+                    url "http://localhost:${mockServer.localPort}"
+                    allowInsecureProtocol = true
                 }        
             }
         """
     }
 
     def cleanup() {
-        repository.stop()
+        repository.close()
+        mockServer.close()
     }
 
     def "can update a version catalog"() {
@@ -108,6 +96,7 @@ class VersionCatalogUpdateFunctionalTest extends AbstractFunctionalTest {
     }
 
     static class LoggingCallback implements ExpectationResponseCallback {
+
         @Override
         HttpResponse handle(HttpRequest httpRequest) throws Exception {
             String path = "/repository${httpRequest.path}"
@@ -124,5 +113,4 @@ class VersionCatalogUpdateFunctionalTest extends AbstractFunctionalTest {
             }
         }
     }
-
 }

--- a/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/compat/FindBaselineTaskTest.groovy
+++ b/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/compat/FindBaselineTaskTest.groovy
@@ -2,23 +2,28 @@ package io.micronaut.build.compat
 
 import io.micronaut.build.utils.ExternalURLService
 import org.gradle.testfixtures.ProjectBuilder
-import org.mockserver.integration.ClientAndServer
-import org.mockserver.model.MediaType
+import software.xdev.mockserver.client.MockServerClient
+import software.xdev.mockserver.model.MediaType
+import software.xdev.mockserver.netty.MockServer
 import spock.lang.Shared
 import spock.lang.Specification
 
 import java.nio.file.Files
 
-import static org.mockserver.model.HttpRequest.request
-import static org.mockserver.model.HttpResponse.response
+import static software.xdev.mockserver.model.HttpRequest.request
+import static software.xdev.mockserver.model.HttpResponse.response
 
 class FindBaselineTaskTest extends Specification {
+
     @Shared
-    private ClientAndServer mockServer
+    private MockServer mockServer
+    @Shared
+    private MockServerClient mockServerClient
 
     def setupSpec() {
-        mockServer = ClientAndServer.startClientAndServer()
-        mockServer.when(
+        mockServer = new MockServer()
+        mockServerClient = new MockServerClient("localhost", mockServer.localPort)
+        mockServerClient.when(
                 request()
                         .withMethod("GET")
                         .withPath("/io/micronaut/micronaut-core/maven-metadata.xml")
@@ -31,7 +36,8 @@ class FindBaselineTaskTest extends Specification {
     }
 
     def cleanupSpec() {
-        mockServer.stop()
+        mockServerClient.close()
+        mockServer.close()
     }
 
     def "parses releases from Maven Central"() {

--- a/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/utils/GithubApiUtilsSpec.groovy
+++ b/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/utils/GithubApiUtilsSpec.groovy
@@ -1,24 +1,31 @@
 package io.micronaut.build.utils
 
 import org.gradle.api.logging.Logger
-import org.mockserver.integration.ClientAndServer
-import org.mockserver.model.MediaType
+import software.xdev.mockserver.client.MockServerClient
+import software.xdev.mockserver.model.MediaType
+import software.xdev.mockserver.netty.MockServer
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.util.environment.RestoreSystemProperties
-import static org.mockserver.model.HttpRequest.request
-import static org.mockserver.model.HttpResponse.response
+
+import java.nio.charset.StandardCharsets
+
+import static software.xdev.mockserver.model.HttpRequest.request
+import static software.xdev.mockserver.model.HttpResponse.response
 
 @RestoreSystemProperties
 class GithubApiUtilsSpec extends Specification {
 
     @Shared
-    private ClientAndServer mockServer
+    private MockServer mockServer
+    @Shared
+    private MockServerClient mockServerClient
 
     def setupSpec() {
-        mockServer = ClientAndServer.startClientAndServer()
+        mockServer = new MockServer()
+        mockServerClient = new MockServerClient("localhost", mockServer.localPort)
         ['tags', 'releases'].each { what ->
-            mockServer.when(
+            mockServerClient.when(
                     request()
                             .withMethod("GET")
                             .withPath("/repos/micronaut-projects/micronaut-security/$what")
@@ -28,7 +35,7 @@ class GithubApiUtilsSpec extends Specification {
                             .withContentType(MediaType.JSON_UTF_8)
                             .withBody(GithubApiUtilsSpec.getResourceAsStream("/io.micronaut.build.utils/releases.json").bytes)
             )
-            mockServer.when(
+            mockServerClient.when(
                     request()
                             .withMethod("GET")
                             .withPath("/repos/micronaut-projects/nope/$what")
@@ -37,23 +44,22 @@ class GithubApiUtilsSpec extends Specification {
                             .withStatusCode(404)
                             .withBody("Not found")
             )
+            System.setProperty(GithubApiUtils.GITHUB_API_BASE_URL_SYSTEM_PROPERTY, "http://localhost:${mockServer.localPort}")
         }
-
-        System.setProperty(GithubApiUtils.GITHUB_API_BASE_URL_SYSTEM_PROPERTY, "http://localhost:${mockServer.localPort}")
     }
 
     def cleanupSpec() {
-        mockServer.stop()
+        mockServerClient.close()
+        mockServer.close()
     }
 
     void "it is possible to fetch tags"() {
+
         when:
-        String tags = new String(GithubApiUtils.fetchTagsFromGitHub(Stub(Logger), "micronaut-projects/micronaut-security"), "UTF-8")
+        var tags = new String(GithubApiUtils.fetchTagsFromGitHub(Stub(Logger), "micronaut-projects/micronaut-security"), StandardCharsets.UTF_8)
 
         then:
         noExceptionThrown()
         tags.contains("v")
     }
-
-
 }


### PR DESCRIPTION
This library `org.mock-server:mockserver-netty` not supported anymore, but found new solution. based on this library: https://github.com/xdev-software/mockserver-neolight