### PR TITLE
Fixed checkstyle errors in generated classes on Windows

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/internal/VersionsWriterTask.java
+++ b/buildSrc/src/main/java/io/micronaut/internal/VersionsWriterTask.java
@@ -22,10 +22,12 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.jspecify.annotations.NonNull;
 
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.util.Locale;
 import java.util.Map;
@@ -50,17 +52,28 @@ public abstract class VersionsWriterTask extends DefaultTask {
         var simpleClassName = className.substring(className.lastIndexOf(".") + 1);
         var parentDir = outputDir.toPath().resolve(packageName.replace('.', '/'));
         Files.createDirectories(parentDir);
-        try (PrintWriter prn = new PrintWriter(new FileWriter(parentDir.resolve(simpleClassName + ".java").toFile()))) {
+        try (var prn = new LfPrintWriter(new FileWriter(parentDir.resolve(simpleClassName + ".java").toFile()))) {
             prn.println("package " + packageName + ";");
             prn.println();
             prn.println("public class " + simpleClassName + " {");
             for (Map.Entry<String, String> entry : versions.entrySet()) {
                 var key = entry.getKey();
-                key = (key + "_VERSION").toUpperCase(Locale.US);
+                key = (key + "_VERSION").toUpperCase(Locale.ENGLISH);
                 prn.println("    public final static String " + key + " = \"" + entry.getValue() + "\";");
             }
             prn.println("}");
         }
+    }
 
+    public static class LfPrintWriter extends PrintWriter {
+
+        public LfPrintWriter(@NonNull Writer out) {
+            super(out);
+        }
+
+        @Override
+        public void println() {
+            print("\n");
+        }
     }
 }

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBomPlugin.java
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBomPlugin.java
@@ -28,6 +28,7 @@ import io.micronaut.build.pom.MicronautBomExtension;
 import io.micronaut.build.pom.PomChecker;
 import io.micronaut.build.pom.PomCheckerUtils;
 import io.micronaut.build.pom.VersionCatalogConverter;
+import io.micronaut.build.utils.LfPrintWriter;
 import org.apache.maven.model.building.DefaultModelBuilder;
 import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.DefaultModelProcessor;
@@ -449,7 +450,7 @@ public abstract class MicronautBomPlugin implements MicronautPlugin<Project> {
         modelConverter.afterBuildingModel(builderState -> {
             api.getAllDependencyConstraints().forEach(MicronautBomPlugin::checkVersionConstraint);
             runtime.getAllDependencyConstraints().forEach(MicronautBomPlugin::checkVersionConstraint);
-            try (var log = new PrintWriter(Files.newBufferedWriter(logFile))) {
+            try (var log = new LfPrintWriter(Files.newBufferedWriter(logFile))) {
                 maybeInlineNestedCatalogs(log, catalogArtifacts, bomArtifacts, builderState, inlineNestedCatalogs, inlineNestedBOMs, excludedInlinedAliases, includedAliases, inlinedPomProperties, inlinedMavenDependencies, project);
                 performVersionInference(log, project, bomExtension, builderState, libraryDefinitions, inlinedPomProperties, inlinedMavenDependencies, project.getConfigurations().findByName(BOM_VERSION_INFERENCE_CONFIGURATION_NAME), knownLibraries);
                 var unresolvedDependencies = new LinkedHashSet<ComponentSelector>();

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/docs/ValidateAsciidocOutputTask.java
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/docs/ValidateAsciidocOutputTask.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.build.docs;
 
+import io.micronaut.build.utils.LfPrintWriter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.DirectoryProperty;
@@ -31,7 +32,6 @@ import org.gradle.api.tasks.TaskAction;
 
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -72,7 +72,7 @@ public abstract class ValidateAsciidocOutputTask extends DefaultTask {
             }
         });
         if (!errors.isEmpty()) {
-            try (PrintWriter prn = new PrintWriter(new FileWriter(getReport().getAsFile().get()))) {
+            try (var prn = new LfPrintWriter(new FileWriter(getReport().getAsFile().get()))) {
                 for (Map.Entry<String, List<String>> entry : errors.entrySet()) {
                     prn.println("In file " + entry.getKey());
                     for (String line : entry.getValue()) {

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/pom/PomChecker.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/pom/PomChecker.groovy
@@ -1,6 +1,8 @@
 package io.micronaut.build.pom
 
 import groovy.transform.CompileStatic
+import io.micronaut.build.utils.LfPrintWriter
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
@@ -18,8 +20,6 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkerExecutor
-
-import javax.inject.Inject
 
 import static org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
 
@@ -155,7 +155,7 @@ abstract class PomChecker extends DefaultTask {
 
         File reportFile = writeReport(errorCollector.errors, errorCollector.suggestions)
         if (failOnError.get() && errorCollector.errors) {
-            try (var writer = new BufferedWriter(new PrintWriter(System.err))) {
+            try (var writer = new BufferedWriter(new LfPrintWriter(System.err))) {
                 writeSuggestions(errorCollector.suggestions, writer)
             }
             throw new GradleException("POM verification failed. See report in ${reportFile}")

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/catalogs/tasks/VersionCatalogUpdate.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/catalogs/tasks/VersionCatalogUpdate.java
@@ -24,6 +24,7 @@ import io.micronaut.build.catalogs.internal.VersionModel;
 import io.micronaut.build.compat.MavenMetadataVersionHelper;
 import io.micronaut.build.utils.ComparableVersion;
 import io.micronaut.build.utils.Downloader;
+import io.micronaut.build.utils.LfPrintWriter;
 import io.micronaut.build.utils.VersionParser;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -140,7 +141,7 @@ public abstract class VersionCatalogUpdate extends DefaultTask {
     }
 
     private void updateCatalog(File inputCatalog, File outputCatalog, File logFile) throws IOException, InterruptedException {
-        try (PrintWriter log = newPrintWriter(logFile)) {
+        try (var log = newPrintWriter(logFile)) {
             log.println("Processing catalog file " + inputCatalog);
             LenientVersionCatalogParser parser = new LenientVersionCatalogParser();
             try (FileInputStream is = new FileInputStream(inputCatalog)) {
@@ -225,7 +226,7 @@ public abstract class VersionCatalogUpdate extends DefaultTask {
             }
 
             getLogger().lifecycle("Writing updated catalog at " + outputCatalog);
-            try (PrintWriter writer = newPrintWriter(outputCatalog)) {
+            try (var writer = newPrintWriter(outputCatalog)) {
                 lines.forEach(writer::println);
             }
 
@@ -354,7 +355,7 @@ public abstract class VersionCatalogUpdate extends DefaultTask {
     }
 
     private static PrintWriter newPrintWriter(File file) throws FileNotFoundException {
-        return new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
+        return new LfPrintWriter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
     }
 
     /**

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/docs/props/JavaDocAtValueReplacementTask.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/docs/props/JavaDocAtValueReplacementTask.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.build.docs.props;
 
+import io.micronaut.build.utils.LfPrintWriter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
@@ -28,7 +29,6 @@ import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -64,7 +64,7 @@ public abstract class JavaDocAtValueReplacementTask extends DefaultTask {
                 if (adocFile.exists()) {
                     String configurationPropertiesClassName = null;
                     List<String> lines = Files.readAllLines(adocFile.toPath(), StandardCharsets.UTF_8);
-                    try (PrintWriter prn = new PrintWriter(outputFile, StandardCharsets.UTF_8.name())) {
+                    try (var prn = new LfPrintWriter(outputFile, StandardCharsets.UTF_8)) {
                         for (int i = 0; i < lines.size(); i++) {
                             String line = lines.get(i);
                             if ("++++".equals(line) && lines.get(i + 1).startsWith("<a id=\"")) {

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/docs/props/MergeConfigurationReferenceTask.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/docs/props/MergeConfigurationReferenceTask.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.build.docs.props;
 
+import io.micronaut.build.utils.LfPrintWriter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
@@ -26,10 +27,7 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -48,12 +46,12 @@ public abstract class MergeConfigurationReferenceTask extends DefaultTask {
     public abstract RegularFileProperty getOutputFile();
 
     @TaskAction
-    protected void merge() throws FileNotFoundException, UnsupportedEncodingException {
+    protected void merge() throws IOException {
         Set<File> inputFiles = getInputFiles().getAsFileTree().getFiles();
         File outputFile = getOutputFile().getAsFile().get();
         File parentFile = outputFile.getParentFile();
         parentFile.mkdirs();
-        try (PrintWriter prn = new PrintWriter(outputFile, StandardCharsets.UTF_8.name())) {
+        try (var prn = new LfPrintWriter(outputFile, StandardCharsets.UTF_8)) {
             inputFiles.stream()
                     .sorted(Comparator.comparing(File::getName))
                     .forEachOrdered(file -> {

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/docs/props/ProcessConfigPropsTask.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/docs/props/ProcessConfigPropsTask.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.build.docs.props;
 
+import io.micronaut.build.utils.LfPrintWriter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
@@ -29,7 +30,6 @@ import org.gradle.api.tasks.TaskAction;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -69,7 +69,7 @@ public abstract class ProcessConfigPropsTask extends DefaultTask {
                     }
                     if (SEPARATOR.equals(line)) {
                         File outputfile = new File(individualConfigsPropsFolder, configurationPropertyName + ".adoc");
-                        try (PrintWriter writer = new PrintWriter(outputfile, StandardCharsets.UTF_8.name())) {
+                        try (var writer = new LfPrintWriter(outputfile, StandardCharsets.UTF_8)) {
                             for (String s : accumulator) {
                                 writer.print(s);
                                 writer.print('\n');

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/docs/props/ReplaceAtLinkTask.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/docs/props/ReplaceAtLinkTask.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.build.docs.props;
 
+import io.micronaut.build.utils.LfPrintWriter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
@@ -27,7 +28,6 @@ import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
@@ -49,7 +49,7 @@ public abstract class ReplaceAtLinkTask extends DefaultTask {
             for (File configPropertiesFile : getInputFiles().getFiles()) {
                 if (configPropertiesFile.exists()) {
                     List<String> lines = Files.readAllLines(configPropertiesFile.toPath(), StandardCharsets.UTF_8);
-                    try (PrintWriter prn = new PrintWriter(outputFile, StandardCharsets.UTF_8.name())) {
+                    try (var prn = new LfPrintWriter(outputFile, StandardCharsets.UTF_8)) {
                         for (String line : lines) {
                             String processedLine = line;
                             while (processedLine.contains("{@link io.micronaut.")) {

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/info/MicronautModuleInfoGeneratorTask.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/info/MicronautModuleInfoGeneratorTask.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.build.info;
 
+import io.micronaut.build.utils.LfPrintWriter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
@@ -28,7 +29,6 @@ import org.gradle.api.tasks.TaskAction;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.stream.Collectors;
@@ -102,13 +102,16 @@ public abstract class MicronautModuleInfoGeneratorTask extends DefaultTask {
         }).getOrElse("null");
         var tags = "Set.of(" + getTags().get().stream().map(tag -> "\"" + escapeJava(tag) + "\"").collect(Collectors.joining(",")) + ")";
 
-        try (var writer = new PrintWriter(Files.newBufferedWriter(outputDir.resolve(fileName), StandardCharsets.UTF_8))) {
+        try (var writer = new LfPrintWriter(Files.newBufferedWriter(outputDir.resolve(fileName), StandardCharsets.UTF_8))) {
             writer.println("package " + packageName + ";");
             writer.println();
             writer.println("import io.micronaut.module.info.AbstractMicronautModuleInfo;");
             writer.println("import io.micronaut.module.info.MavenCoordinates;");
             writer.println("import java.util.Set;");
             writer.println();
+            writer.println("/**");
+            writer.println(" * Generated Micronaut module info class for " + name + ".");
+            writer.println(" */");
             writer.println("public class " + className + " extends AbstractMicronautModuleInfo {");
             writer.println("    public " + className + "() {");
             writer.println("        super(\"" + ga + "\", ");
@@ -121,11 +124,12 @@ public abstract class MicronautModuleInfoGeneratorTask extends DefaultTask {
             writer.println("        );");
             writer.println("    }");
             writer.println("}");
+            writer.println();
         }
 
         var metaInfDir = outputDir.resolve("META-INF/services");
         Files.createDirectories(metaInfDir);
-        try (var writer = new PrintWriter(Files.newBufferedWriter(metaInfDir.resolve("io.micronaut.module.info.MicronautModuleInfo"), StandardCharsets.UTF_8))) {
+        try (var writer = new LfPrintWriter(Files.newBufferedWriter(metaInfDir.resolve("io.micronaut.module.info.MicronautModuleInfo"), StandardCharsets.UTF_8))) {
             writer.println(packageName + "." + className);
         }
     }

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/utils/LfPrintWriter.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/utils/LfPrintWriter.java
@@ -1,0 +1,30 @@
+package io.micronaut.build.utils;
+
+import org.jspecify.annotations.NonNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+
+public class LfPrintWriter extends PrintWriter {
+
+    public LfPrintWriter(OutputStream out) {
+        super(out);
+    }
+
+    public LfPrintWriter(@NonNull Writer out) {
+        super(out);
+    }
+
+    public LfPrintWriter(File file, Charset charset) throws IOException {
+        super(file, charset);
+    }
+
+    @Override
+    public void println() {
+        print("\n");
+    }
+}


### PR DESCRIPTION
Now I see this errors every build:

<img width="1729" height="315" alt="изображение" src="https://github.com/user-attachments/assets/bf5c8f46-d0bf-4910-8479-9df32966faab" />

This PR fixes problem with `CRLF` / `LF` and added missing Javadoc to generated class.