### PR TITLE
Bump kotlin-ksp version to 2.3.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ junit6 = "6.0.1"
 logback = "1.5.20"
 checkstyle = "12.1.0"
 kotlin = "2.3.0"
-kotlin-ksp = "2.3.4"
+kotlin-ksp = "2.3.6"
 
 [libraries]
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }


### PR DESCRIPTION
     Bump kotlin-ksp to 2.3.6 so micronaut-kotlin-build-plugins pulls kotlin-stdlib 2.3.x, which supports Java 25.                                                                           