### PR TITLE
Add Gradle Toolchains opt-in coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,22 @@ Default values are:
 
 ```groovy
 micronautBuild {
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
+    javaVersion = 25
+    testJavaVersion = JavaVersion.current().majorVersion as Integer
 
     checkstyleVersion = '8.33'
 
     dependencyUpdatesPattern = /.+(-|\.?)(b|M|RC)\d.*/
 }
 ```
+
+By default, the build uses Gradle's source and target compatibility settings so
+projects continue to work with only the current JDK installed. Gradle
+Toolchains remain opt-in: set `USE_GRADLE_TOOLCHAINS` to an empty value or
+`true` to use `micronautBuild.javaVersion` for compilation toolchains and
+`micronautBuild.testJavaVersion` for `Test` task launchers. Set
+`USE_GRADLE_TOOLCHAINS=false` or leave it unset to keep the default single-JDK
+behavior.
 
 Also, to pin a dependency to a particular version:
 

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/AbstractFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/AbstractFunctionalTest.groovy
@@ -31,6 +31,8 @@ abstract class AbstractFunctionalTest extends Specification {
 
     String gradleVersion
     boolean debug
+    Map<String, String> environment = [:]
+    Set<String> removedEnvironment = [] as Set
 
     private StringWriter outputWriter
     private StringWriter errorOutputWriter
@@ -121,6 +123,12 @@ abstract class AbstractFunctionalTest extends Specification {
                 .withPluginClasspath()
                 .withProjectDir(testDirectory.toFile())
                 .withArguments([*autoArgs, *args])
+        if (!environment.isEmpty() || !removedEnvironment.isEmpty()) {
+            def effectiveEnvironment = new LinkedHashMap<String, String>(System.getenv())
+            removedEnvironment.each { effectiveEnvironment.remove(it) }
+            effectiveEnvironment.putAll(environment)
+            runner.withEnvironment(effectiveEnvironment)
+        }
         if (gradleVersion) {
             runner.withGradleVersion(gradleVersion)
         }

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/ToolchainsFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/ToolchainsFunctionalTest.groovy
@@ -1,0 +1,134 @@
+package io.micronaut.build
+
+class ToolchainsFunctionalTest extends AbstractFunctionalTest {
+
+    void "USE_GRADLE_TOOLCHAINS value '#valueLabel' configures useToolchains as #expected"() {
+        given:
+        withSample("test-micronaut-module")
+        configureUseToolchainsEnvironment(value)
+
+        file("subproject1/build.gradle") << """
+            tasks.register("printUseToolchains") {
+                doLast {
+                    println "useToolchains=\${micronautBuild.useToolchains.get()}"
+                }
+            }
+        """
+
+        when:
+        run ':subproject1:printUseToolchains'
+
+        then:
+        outputContains "useToolchains=${expected}"
+
+        where:
+        value   | expected | valueLabel
+        null    | false    | "<unset>"
+        ""      | true     | "<empty>"
+        "true"  | true     | "true"
+        "false" | false    | "false"
+    }
+
+    void "non-toolchain mode keeps source and target compatibility on javaVersion and leaves tests on current JDK"() {
+        given:
+        withSample("test-micronaut-module")
+        configureUseToolchainsEnvironment(null)
+        file("subproject1/build.gradle") << """
+            micronautBuild {
+                javaVersion = ${differentJdk}
+                testJavaVersion = ${differentJdk}
+            }
+
+            ${printJavaConfigurationTask()}
+        """
+
+        when:
+        run ':subproject1:printJavaConfiguration'
+
+        then:
+        outputContains "useToolchains=false"
+        outputContains "sourceCompatibility=${differentJdk}"
+        outputContains "targetCompatibility=${differentJdk}"
+        outputContains "toolchainLanguageVersion=unset"
+        outputContains "testJavaLauncher=${currentJdk}"
+    }
+
+    void "toolchain mode keeps compilation and test JVM versions independent"() {
+        given:
+        withSample("test-micronaut-module")
+        configureUseToolchainsEnvironment("true")
+        file("subproject1/build.gradle") << """
+            micronautBuild {
+                javaVersion = ${differentJdk}
+                testJavaVersion = ${currentJdk}
+            }
+
+            ${printJavaConfigurationTask()}
+        """
+
+        when:
+        run ':subproject1:printJavaConfiguration'
+
+        then:
+        outputContains "useToolchains=true"
+        outputContains "toolchainLanguageVersion=${differentJdk}"
+        outputContains "testJavaLauncher=${currentJdk}"
+    }
+
+    void "legacy compatibility overrides keep clearing toolchain language version"() {
+        given:
+        withSample("test-micronaut-module")
+        configureUseToolchainsEnvironment("true")
+        file("subproject1/build.gradle") << """
+            micronautBuild {
+                javaVersion = ${differentJdk}
+                sourceCompatibility = "11"
+            }
+
+            ${printJavaConfigurationTask()}
+        """
+
+        when:
+        run ':subproject1:printJavaConfiguration'
+
+        then:
+        outputContains """The "sourceCompatibility" and "targetCompatibility" properties are deprecated.
+Please use "micronautBuild.javaVersion" instead.
+You can do this directly in the project, or, better, in a convention plugin if it exists."""
+        outputContains "sourceCompatibility=11"
+        outputContains "targetCompatibility=11"
+        outputContains "toolchainLanguageVersion=unset"
+    }
+
+    private void configureUseToolchainsEnvironment(String value) {
+        if (value == null) {
+            removedEnvironment << "USE_GRADLE_TOOLCHAINS"
+        } else {
+            environment["USE_GRADLE_TOOLCHAINS"] = value
+        }
+    }
+
+    private String getCurrentJdk() {
+        System.getProperty("CURRENT_JDK")
+    }
+
+    private String getDifferentJdk() {
+        currentJdk == "17" ? "21" : "17"
+    }
+
+    private static String printJavaConfigurationTask() {
+        """
+            tasks.register("printJavaConfiguration") {
+                doLast {
+                    def javaExtension = project.extensions.getByName("java")
+                    def testTask = project.tasks.named("test").get()
+                    println "useToolchains=\${micronautBuild.useToolchains.get()}"
+                    println "sourceCompatibility=\${javaExtension.sourceCompatibility}"
+                    println "targetCompatibility=\${javaExtension.targetCompatibility}"
+                    println "toolchainLanguageVersion=\${javaExtension.toolchain.languageVersion.orNull?.asInt() ?: 'unset'}"
+                    println "testJavaLauncher=\${testTask.javaLauncher.orNull?.metadata?.languageVersion?.asInt() ?: 'unset'}"
+                }
+            }
+        """
+    }
+}


### PR DESCRIPTION
This PR hardens the existing opt-in Gradle Toolchains support by adding focused functional coverage for the environment flag and Java compile/test launcher separation. It keeps the default single-JDK behavior unchanged and documents the current `javaVersion` / `testJavaVersion` configuration knobs in the README.

The new functional tests cover:

- `USE_GRADLE_TOOLCHAINS` unset, empty, `true`, and `false` parsing
- non-toolchain mode using `micronautBuild.javaVersion` for source/target compatibility while leaving tests on the current JDK
- toolchain mode using separate compile and `Test` launcher Java versions
- legacy `sourceCompatibility` / `targetCompatibility` overrides clearing the toolchain language version

Project routing: QA selected `5.0.0-M3` and `5.0.0 Release`; the generic `Micronaut Framework` project was also open but considered less precise for this release-tracking work. Live project-link application was attempted, but the available GitHub authentication is missing the `project` scope, and the Paperclip GitHub plugin project-link tool is not exposed in this runtime.

Verification:

- `./gradlew :micronaut-gradle-plugins:functionalTest --tests 'io.micronaut.build.ToolchainsFunctionalTest' --rerun-tasks`

Closes micronaut-projects/micronaut-build#480

---
###### ✨ This message was AI-generated using GPT-5