### PR TITLE
Fix jacocoTestReport aggregate reporting

### DIFF
--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/quality/QualityReportingPluginFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/quality/QualityReportingPluginFunctionalTest.groovy
@@ -21,6 +21,24 @@ class QualityReportingPluginFunctionalTest extends AbstractFunctionalTest {
         file("build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml").exists()
     }
 
+    void "jacocoTestReport runs aggregate coverage reports"() {
+        given:
+        withSample("test-micronaut-module")
+        file("gradle.properties") << "micronaut.jacoco.enabled=true"
+
+        when:
+        run 'jacocoTestReport'
+
+        then:
+        tasks {
+            succeeded ':subproject1:test'
+            succeeded ':subproject2:test'
+            succeeded ':testCodeCoverageReport'
+            succeeded ':jacocoTestReport'
+        }
+        file("build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml").exists()
+    }
+
     void "it can run Spotless and Checkstyle"() {
         given:
         withSample("test-micronaut-module")

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautQualityReportingAggregatorPlugin.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautQualityReportingAggregatorPlugin.java
@@ -81,9 +81,10 @@ public class MicronautQualityReportingAggregatorPlugin implements Plugin<Project
         rootProject.afterEvaluate(unused -> {
             if (!rootProject.getTasks().getNames().contains("jacocoTestReport")) {
                 rootProject.getTasks().register("jacocoTestReport", t ->  {
-                   t.setDescription("Placeholder task for Jacoco reports");
+                   t.setDescription("Generates aggregate Jacoco reports");
+                   t.dependsOn(COVERAGE_REPORT_TASK_NAME);
                    t.doFirst(unused2 -> {
-                       System.out.println("Placeholder task for Jacoco reports");
+                       System.out.println("Generating aggregate Jacoco reports");
                    });
                 });
             }


### PR DESCRIPTION
## Summary
- make the root `jacocoTestReport` fallback run the existing aggregate `testCodeCoverageReport` task
- update the fallback task description/output so it reflects aggregate report generation
- add functional coverage for the issue-reported `jacocoTestReport` command and aggregate XML report path

## Tests
- `./gradlew :micronaut-gradle-plugins:functionalTest --tests 'io.micronaut.build.quality.QualityReportingPluginFunctionalTest.jacocoTestReport runs aggregate coverage reports'`
- Prior implementation verification: `./gradlew :micronaut-gradle-plugins:functionalTest --tests 'io.micronaut.build.quality.QualityReportingPluginFunctionalTest'`
- Prior implementation verification: `./gradlew :micronaut-gradle-plugins:check`

Closes #582

## Paperclip
- Paperclip issue: DEV-131
- Type label: `type: bug`
- Organization projects: no matching open Micronaut org project was visible for the `8.0.x` / `8.0.0-SNAPSHOT` target line; no project link applied.

---
###### ✨ This message was AI-generated using gpt-5