### PR TITLE
Fix micronaut build version for build-logic

### DIFF
--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
@@ -1,5 +1,8 @@
 package io.micronaut.build
 
+import java.nio.file.Files
+import java.nio.file.Path
+
 class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
 
     void "defaults to Java 25"() {
@@ -120,6 +123,48 @@ class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
 
         then:
         errorOutputContains "Micronaut build version directory must stay under the settings root: ../outside"
+    }
+
+    void "rejects configured micronaut build version directory symlink outside settings root"() {
+        given:
+        settingsFile << """
+            plugins {
+                id 'io.micronaut.build.shared.settings'
+            }
+
+            micronautBuild {
+                micronautBuildVersionDirectories.add('custom-build-logic')
+            }
+        """
+        buildFile << ""
+        Path outsideDirectory = Files.createTempDirectory(testDirectory.parent, "outside-build-logic")
+        Files.createSymbolicLink(testDirectory.resolve("custom-build-logic"), outsideDirectory)
+
+        when:
+        fails 'help'
+
+        then:
+        errorOutputContains "Micronaut build version directory must stay under the settings root: custom-build-logic"
+        !outsideDirectory.resolve("gradle.properties").toFile().exists()
+    }
+
+    void "rejects default micronaut build version directory symlink outside settings root"() {
+        given:
+        settingsFile << """
+            plugins {
+                id 'io.micronaut.build.shared.settings'
+            }
+        """
+        buildFile << ""
+        Path outsideDirectory = Files.createTempDirectory(testDirectory.parent, "outside-build-logic")
+        Files.createSymbolicLink(testDirectory.resolve("build-logic"), outsideDirectory)
+
+        when:
+        fails 'help'
+
+        then:
+        errorOutputContains "Micronaut build version directory must stay under the settings root: build-logic"
+        !outsideDirectory.resolve("gradle.properties").toFile().exists()
     }
 
    void "warns if using #property compatibility"() {

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
@@ -60,7 +60,18 @@ class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
             includeBuild 'build-logic'
         """
         buildFile << ""
-        file("build-logic/settings.gradle") << """
+        writeIncludedBuild("build-logic")
+
+        when:
+        run 'help'
+
+        then:
+        file("build-logic/gradle.properties").text.contains("micronaut-build-version=")
+    }
+
+    void "writes micronaut build version for configured included build directory"() {
+        given:
+        settingsFile << """
             pluginManagement {
                 repositories {
                     gradlePluginPortal()
@@ -68,27 +79,47 @@ class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
                 }
             }
 
-            rootProject.name = 'build-logic'
-        """
-        file("build-logic/build.gradle") << """
             plugins {
-                id 'groovy-gradle-plugin'
+                id 'io.micronaut.build.shared.settings'
             }
 
-            repositories {
-                mavenCentral()
+            micronautBuild {
+                micronautBuildVersionDirectories.add('custom-build-logic')
             }
 
-            dependencies {
-                implementation(providers.gradleProperty("micronaut-build-version").map { "io.micronaut.build.internal:micronaut-kotlin-build-plugins:\${it}" }.get())
-            }
+            rootProject.name = 'test-custom-build-logic'
+            includeBuild 'custom-build-logic'
         """
+        buildFile << ""
+        writeIncludedBuild("custom-build-logic")
+        file("other-build-logic/settings.gradle") << "rootProject.name = 'other-build-logic'"
 
         when:
         run 'help'
 
         then:
-        file("build-logic/gradle.properties").text.contains("micronaut-build-version=")
+        file("custom-build-logic/gradle.properties").text.contains("micronaut-build-version=")
+        !file("other-build-logic/gradle.properties").exists()
+    }
+
+    void "rejects unsafe micronaut build version directory"() {
+        given:
+        settingsFile << """
+            plugins {
+                id 'io.micronaut.build.shared.settings'
+            }
+
+            micronautBuild {
+                micronautBuildVersionDirectories.add('../outside')
+            }
+        """
+        buildFile << ""
+
+        when:
+        fails 'help'
+
+        then:
+        errorOutputContains "Micronaut build version directory must stay under the settings root: ../outside"
     }
 
    void "warns if using #property compatibility"() {
@@ -140,5 +171,31 @@ You can do this directly in the project, or, better, in a convention plugin if i
             succeeded ':subproject1:compileTestGroovy' // uses Spock by default
             succeeded ':subproject2:compileTestJava' // overrides to JUnit5
         }
+    }
+
+    private void writeIncludedBuild(String name) {
+        file("${name}/settings.gradle") << """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+            }
+
+            rootProject.name = '${name}'
+        """
+        file("${name}/build.gradle") << """
+            plugins {
+                id 'groovy-gradle-plugin'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation(providers.gradleProperty("micronaut-build-version").map { "io.micronaut.build.internal:micronaut-kotlin-build-plugins:\${it}" }.get())
+            }
+        """
     }
 }

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
@@ -42,6 +42,55 @@ class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
         outputContains "Java version: ${System.getProperty('CURRENT_JDK')}"
     }
 
+    void "writes micronaut build version for build logic included builds"() {
+        given:
+        settingsFile << """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+            }
+
+            plugins {
+                id 'io.micronaut.build.shared.settings'
+            }
+
+            rootProject.name = 'test-build-logic'
+            includeBuild 'build-logic'
+        """
+        buildFile << ""
+        file("build-logic/settings.gradle") << """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+            }
+
+            rootProject.name = 'build-logic'
+        """
+        file("build-logic/build.gradle") << """
+            plugins {
+                id 'groovy-gradle-plugin'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation(providers.gradleProperty("micronaut-build-version").map { "io.micronaut.build.internal:micronaut-kotlin-build-plugins:\${it}" }.get())
+            }
+        """
+
+        when:
+        run 'help'
+
+        then:
+        file("build-logic/gradle.properties").text.contains("micronaut-build-version=")
+    }
+
    void "warns if using #property compatibility"() {
         given:
         withSample("test-micronaut-module")

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautBuildSettingsExtension.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautBuildSettingsExtension.java
@@ -89,6 +89,14 @@ public abstract class MicronautBuildSettingsExtension {
      */
     public abstract ListProperty<String> getNonStandardProjectNamePrefixes();
 
+    /**
+     * Configures root-relative directories whose {@code gradle.properties} should
+     * receive the current Micronaut Build version for included build dependency wiring.
+     *
+     * @return the list of directories
+     */
+    public abstract ListProperty<String> getMicronautBuildVersionDirectories();
+
     @Inject
     protected abstract ProviderFactory getProviders();
 
@@ -110,6 +118,7 @@ public abstract class MicronautBuildSettingsExtension {
         getUseStandardizedProjectNames().convention(false);
         getNonStandardProjectPathPrefixes().set(Collections.singletonList(":examples:"));
         getNonStandardProjectNamePrefixes().set(Arrays.asList(MICRONAUT_PROJECT_PREFIX, TEST_SUITE_PROJECT_PREFIX));
+        getMicronautBuildVersionDirectories().convention(Arrays.asList("buildSrc", "build-logic"));
         this.versionCatalogTomlModel = loadVersionCatalogTomlModel();
         this.micronautVersion = determineMicronautVersion();
         this.micronautTestVersion = determineMicronautTestVersion();

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
@@ -82,6 +82,25 @@ public class MicronautSharedSettingsPlugin implements MicronautPlugin<Settings> 
         var rootDir = settings.getRootDir().toPath();
         writeMicronautBuildVersionIfPresent(rootDir.resolve("buildSrc"));
         writeMicronautBuildVersionIfPresent(rootDir.resolve("build-logic"));
+        settings.getGradle().settingsEvaluated(unused -> writeMicronautBuildVersions(rootDir, buildSettingsExtension.getMicronautBuildVersionDirectories().get()));
+    }
+
+    private static void writeMicronautBuildVersions(Path rootDirectory, List<String> directories) {
+        for (String directory : directories) {
+            writeMicronautBuildVersionIfPresent(resolveMicronautBuildVersionDirectory(rootDirectory, directory));
+        }
+    }
+
+    private static Path resolveMicronautBuildVersionDirectory(Path rootDirectory, String directory) {
+        Path directoryPath = Path.of(directory);
+        if (directoryPath.isAbsolute()) {
+            throw new InvalidUserCodeException("Micronaut build version directory must be root-relative: " + directory);
+        }
+        Path candidateDirectory = rootDirectory.resolve(directoryPath).normalize();
+        if (!candidateDirectory.startsWith(rootDirectory)) {
+            throw new InvalidUserCodeException("Micronaut build version directory must stay under the settings root: " + directory);
+        }
+        return candidateDirectory;
     }
 
     private static void writeMicronautBuildVersionIfPresent(Path candidateDirectory) {
@@ -94,7 +113,7 @@ public class MicronautSharedSettingsPlugin implements MicronautPlugin<Settings> 
         var gradleProperties = directory.resolve("gradle.properties");
         var props = new Properties();
         if (Files.exists(gradleProperties)) {
-            try (var reader = Files.newBufferedReader(gradleProperties)) {
+            try (var reader = Files.newBufferedReader(gradleProperties, StandardCharsets.ISO_8859_1)) {
                 props.load(reader);
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
@@ -80,14 +80,18 @@ public class MicronautSharedSettingsPlugin implements MicronautPlugin<Settings> 
             }
         });
         var rootDir = settings.getRootDir().toPath();
-        var buildSrc = rootDir.resolve("buildSrc");
-        if (Files.isDirectory(buildSrc)) {
-            writeMicronautBuildVersion(buildSrc);
+        writeMicronautBuildVersionIfPresent(rootDir.resolve("buildSrc"));
+        writeMicronautBuildVersionIfPresent(rootDir.resolve("build-logic"));
+    }
+
+    private static void writeMicronautBuildVersionIfPresent(Path buildLogicDirectory) {
+        if (Files.isDirectory(buildLogicDirectory)) {
+            writeMicronautBuildVersion(buildLogicDirectory);
         }
     }
 
-    private static void writeMicronautBuildVersion(Path buildSrc) {
-        var gradleProperties = buildSrc.resolve("gradle.properties");
+    private static void writeMicronautBuildVersion(Path buildLogicDirectory) {
+        var gradleProperties = buildLogicDirectory.resolve("gradle.properties");
         var props = new Properties();
         if (Files.exists(gradleProperties)) {
             try (var reader = Files.newBufferedReader(gradleProperties)) {

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
@@ -35,6 +35,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
@@ -79,15 +80,15 @@ public class MicronautSharedSettingsPlugin implements MicronautPlugin<Settings> 
                 extraProperties.set("micronautVersion", buildSettingsExtension.getMicronautVersion());
             }
         });
-        var rootDir = settings.getRootDir().toPath();
-        writeMicronautBuildVersionIfPresent(rootDir.resolve("buildSrc"));
-        writeMicronautBuildVersionIfPresent(rootDir.resolve("build-logic"));
+        var rootDir = settings.getRootDir().toPath().toAbsolutePath().normalize();
+        writeMicronautBuildVersionIfPresent(rootDir, resolveMicronautBuildVersionDirectory(rootDir, "buildSrc"), "buildSrc");
+        writeMicronautBuildVersionIfPresent(rootDir, resolveMicronautBuildVersionDirectory(rootDir, "build-logic"), "build-logic");
         settings.getGradle().settingsEvaluated(unused -> writeMicronautBuildVersions(rootDir, buildSettingsExtension.getMicronautBuildVersionDirectories().get()));
     }
 
     private static void writeMicronautBuildVersions(Path rootDirectory, List<String> directories) {
         for (String directory : directories) {
-            writeMicronautBuildVersionIfPresent(resolveMicronautBuildVersionDirectory(rootDirectory, directory));
+            writeMicronautBuildVersionIfPresent(rootDirectory, resolveMicronautBuildVersionDirectory(rootDirectory, directory), directory);
         }
     }
 
@@ -103,9 +104,24 @@ public class MicronautSharedSettingsPlugin implements MicronautPlugin<Settings> 
         return candidateDirectory;
     }
 
-    private static void writeMicronautBuildVersionIfPresent(Path candidateDirectory) {
-        if (Files.isDirectory(candidateDirectory)) {
-            writeMicronautBuildVersion(candidateDirectory);
+    private static void writeMicronautBuildVersionIfPresent(Path rootDirectory, Path candidateDirectory, String directory) {
+        if (Files.exists(candidateDirectory, LinkOption.NOFOLLOW_LINKS)) {
+            Path realRootDirectory = toRealPath(rootDirectory, "settings root");
+            Path realCandidateDirectory = toRealPath(candidateDirectory, "Micronaut build version directory " + directory);
+            if (!realCandidateDirectory.startsWith(realRootDirectory)) {
+                throw new InvalidUserCodeException("Micronaut build version directory must stay under the settings root: " + directory);
+            }
+            if (Files.isDirectory(realCandidateDirectory)) {
+                writeMicronautBuildVersion(realCandidateDirectory);
+            }
+        }
+    }
+
+    private static Path toRealPath(Path path, String description) {
+        try {
+            return path.toRealPath();
+        } catch (IOException e) {
+            throw new InvalidUserCodeException(description + " must resolve to an existing path: " + path, e);
         }
     }
 

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautSharedSettingsPlugin.java
@@ -84,14 +84,14 @@ public class MicronautSharedSettingsPlugin implements MicronautPlugin<Settings> 
         writeMicronautBuildVersionIfPresent(rootDir.resolve("build-logic"));
     }
 
-    private static void writeMicronautBuildVersionIfPresent(Path buildLogicDirectory) {
-        if (Files.isDirectory(buildLogicDirectory)) {
-            writeMicronautBuildVersion(buildLogicDirectory);
+    private static void writeMicronautBuildVersionIfPresent(Path candidateDirectory) {
+        if (Files.isDirectory(candidateDirectory)) {
+            writeMicronautBuildVersion(candidateDirectory);
         }
     }
 
-    private static void writeMicronautBuildVersion(Path buildLogicDirectory) {
-        var gradleProperties = buildLogicDirectory.resolve("gradle.properties");
+    private static void writeMicronautBuildVersion(Path directory) {
+        var gradleProperties = directory.resolve("gradle.properties");
         var props = new Properties();
         if (Files.exists(gradleProperties)) {
             try (var reader = Files.newBufferedReader(gradleProperties)) {


### PR DESCRIPTION
## Summary
- Keep the existing `buildSrc` support and the reported `build-logic` support for writing `micronaut-build-version` when the shared settings plugin is applied.
- Add `micronautBuild.micronautBuildVersionDirectories` so projects can explicitly opt in additional root-relative included-build directories instead of relying on a hardcoded name or scanning arbitrary folders.
- Validate configured directories so the writer stays under the settings root, and read/write `gradle.properties` with the same ISO-8859-1 charset.
- Add functional coverage for the reported `build-logic` case, a custom included-build directory name, and unsafe path rejection.

## Verification
- `./gradlew :micronaut-gradle-plugins:functionalTest --tests 'io.micronaut.build.PluginDefaultsFunctionalTest.*build version*'`
- `./gradlew :micronaut-gradle-plugins:check`
- `./gradlew check`
- `git diff --check`

## Paperclip Review
- Type: `type: bug`
- Project selection: `5.0.0-M3` and `5.0.0 Release`
- Live project links were repaired after this update.

Closes #835.

---
###### ✨ This message was AI-generated using gpt-5.5