### PR TITLE
Add docs link verification task

### DIFF
--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/docs/DocsLinksFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/docs/DocsLinksFunctionalTest.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.build.docs
+
+import io.micronaut.build.AbstractFunctionalTest
+
+class DocsLinksFunctionalTest extends AbstractFunctionalTest {
+
+    void "check docs links task is available but not part of docs task"() {
+        given:
+        withSample("test-micronaut-module")
+
+        when:
+        run "tasks", "--all"
+
+        then:
+        outputContains("checkDocsLinks")
+
+        when:
+        run "docs", "--dry-run"
+
+        then:
+        outputContains(":docs SKIPPED")
+        outputDoesNotContain(":checkDocsLinks")
+
+        when:
+        run "checkDocsLinks", "--dry-run"
+
+        then:
+        outputContains(":assembleFinalDocs SKIPPED")
+        outputContains(":checkDocsLinks SKIPPED")
+    }
+}

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautDocsPlugin.groovy
@@ -6,6 +6,7 @@ import io.micronaut.build.docs.JavadocAggregatorPlugin
 import io.micronaut.build.docs.PrepareDocResourcesTask
 import io.micronaut.build.docs.PublishGuideTask
 import io.micronaut.build.docs.ValidateAsciidocOutputTask
+import io.micronaut.build.docs.ValidateGuideLinksTask
 import io.micronaut.build.docs.props.MergeConfigurationReferenceTask
 import io.micronaut.build.docs.props.PublishConfigurationReferenceTask
 import io.micronaut.build.utils.GitHubApiService
@@ -236,6 +237,18 @@ abstract class MicronautDocsPlugin implements Plugin<Project> {
                 into('guide') {
                     from(createReleasesDropdown)
                 }
+            }
+
+            tasks.register("checkDocsLinks", ValidateGuideLinksTask) { task ->
+                task.group = DOCUMENTATION_GROUP
+                task.description = "Verify generated guide index and configuration reference links"
+                task.dependsOn assembleFinalDocs
+                task.docsDirectory = layout.buildDirectory.dir("docs")
+                task.htmlFiles.from(
+                        layout.buildDirectory.file("docs/guide/${INDEX_HTML}"),
+                        layout.buildDirectory.file("docs/guide/${CONFIGURATION_REFERENCE_HTML}")
+                )
+                task.report = layout.buildDirectory.file("working/reports/docs-links.txt")
             }
 
             tasks.register("docs") { task ->

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/docs/ValidateGuideLinksTask.java
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/docs/ValidateGuideLinksTask.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2003-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.docs;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static io.micronaut.build.utils.ConsoleUtils.clickableUrl;
+
+@CacheableTask
+public abstract class ValidateGuideLinksTask extends DefaultTask {
+
+    private static final List<String> IGNORED_SCHEMES = List.of("http", "https", "mailto", "tel", "javascript", "data");
+
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract DirectoryProperty getDocsDirectory();
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getHtmlFiles();
+
+    @Input
+    @Optional
+    public abstract Property<Boolean> getFailOnError();
+
+    @OutputFile
+    public abstract RegularFileProperty getReport();
+
+    @TaskAction
+    void validate() throws IOException {
+        List<String> errors = new ArrayList<>();
+        File docsDirectory = getDocsDirectory().getAsFile().get().getCanonicalFile();
+        for (File htmlFile : getHtmlFiles().getFiles()) {
+            validateFile(docsDirectory, htmlFile.getCanonicalFile(), errors);
+        }
+        writeReport(errors);
+        if (!errors.isEmpty() && getFailOnError().getOrElse(true)) {
+            throw new GradleException(
+                    "Validation of generated guide links failed. See the report at " + clickableUrl(getReport().getAsFile().get())
+            );
+        }
+    }
+
+    private void validateFile(File docsDirectory, File htmlFile, List<String> errors) throws IOException {
+        if (!htmlFile.isFile()) {
+            errors.add("Missing HTML file " + docsDirectory.toPath().relativize(htmlFile.toPath()));
+            return;
+        }
+        Document document = Jsoup.parse(htmlFile, "UTF-8");
+        for (Element link : document.select("a[href]")) {
+            String href = link.attr("href").trim();
+            if (href.isEmpty() || shouldIgnore(href)) {
+                continue;
+            }
+            LinkTarget target = parseTarget(href);
+            File targetFile = target.path.isEmpty() ? htmlFile : new File(htmlFile.getParentFile(), target.path).getCanonicalFile();
+            if (!isInsideDirectory(docsDirectory, targetFile)) {
+                errors.add(formatError(docsDirectory, htmlFile, href, "points outside the docs directory"));
+            } else if (!targetFile.isFile()) {
+                errors.add(formatError(
+                        docsDirectory,
+                        htmlFile,
+                        href,
+                        "missing target file " + docsDirectory.toPath().relativize(targetFile.toPath())
+                ));
+            } else if (!target.fragment.isEmpty() && !containsFragment(targetFile, target.fragment)) {
+                errors.add(formatError(docsDirectory, htmlFile, href, "missing fragment #" + target.fragment));
+            }
+        }
+    }
+
+    private static boolean shouldIgnore(String href) {
+        if ("#".equals(href)) {
+            return true;
+        }
+        if (href.startsWith("//")) {
+            return true;
+        }
+        String lowerHref = href.toLowerCase(Locale.ROOT);
+        int colon = lowerHref.indexOf(':');
+        return colon > 0 && IGNORED_SCHEMES.contains(lowerHref.substring(0, colon));
+    }
+
+    private static LinkTarget parseTarget(String href) {
+        String path = href;
+        String fragment = "";
+        int hash = path.indexOf('#');
+        if (hash >= 0) {
+            fragment = path.substring(hash + 1);
+            path = path.substring(0, hash);
+        }
+        int query = path.indexOf('?');
+        if (query >= 0) {
+            path = path.substring(0, query);
+        }
+        return new LinkTarget(path, fragment);
+    }
+
+    private static boolean containsFragment(File targetFile, String fragment) throws IOException {
+        Document targetDocument = Jsoup.parse(targetFile, "UTF-8");
+        if (targetDocument.getElementById(fragment) != null) {
+            return true;
+        }
+        for (Element anchor : targetDocument.select("a[name]")) {
+            if (fragment.equals(anchor.attr("name"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isInsideDirectory(File directory, File file) {
+        Path directoryPath = directory.toPath();
+        Path filePath = file.toPath();
+        return filePath.startsWith(directoryPath);
+    }
+
+    private void writeReport(List<String> errors) throws IOException {
+        File report = getReport().getAsFile().get();
+        report.getParentFile().mkdirs();
+        try (PrintWriter prn = new PrintWriter(new FileWriter(report))) {
+            if (errors.isEmpty()) {
+                prn.println("No broken links found.");
+            } else {
+                for (String error : errors) {
+                    prn.println(error);
+                }
+            }
+        }
+    }
+
+    private static String formatError(File docsDirectory, File sourceFile, String href, String message) {
+        return docsDirectory.toPath().relativize(sourceFile.toPath()) + ": link '" + href + "' " + message;
+    }
+
+    private static final class LinkTarget {
+        private final String path;
+        private final String fragment;
+
+        private LinkTarget(String path, String fragment) {
+            this.path = path;
+            this.fragment = fragment;
+        }
+    }
+}

--- a/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/docs/ValidateGuideLinksTaskSpec.groovy
+++ b/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/docs/ValidateGuideLinksTaskSpec.groovy
@@ -1,0 +1,79 @@
+package io.micronaut.build.docs
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
+
+class ValidateGuideLinksTaskSpec extends Specification {
+
+    @TempDir
+    Path testDirectory
+
+    void "passes when local file and fragment links resolve"() {
+        given:
+        def docsDir = file("docs")
+        file("docs/guide/index.html").text = '''
+            <a href="configurationreference.html#config-reference">Configuration Reference</a>
+            <a href="https://docs.micronaut.io/latest/api/">API</a>
+            <a href="//cdn.example.com/library.js">CDN</a>
+        '''
+        file("docs/guide/configurationreference.html").text = '<h1 id="config-reference">Configuration Reference</h1>'
+        def task = task(docsDir, file("docs/guide/index.html"), file("docs/guide/configurationreference.html"))
+
+        when:
+        task.validate()
+
+        then:
+        file("report.txt").text.contains("No broken links found.")
+    }
+
+    void "fails when a local file target is missing"() {
+        given:
+        def docsDir = file("docs")
+        file("docs/guide/index.html").text = '<a href="missing.html">Missing</a>'
+        file("docs/guide/configurationreference.html").text = ''
+        def task = task(docsDir, file("docs/guide/index.html"), file("docs/guide/configurationreference.html"))
+
+        when:
+        task.validate()
+
+        then:
+        thrown(GradleException)
+        file("report.txt").text.contains("guide/index.html: link 'missing.html' missing target file guide/missing.html")
+    }
+
+    void "fails when a local fragment target is missing"() {
+        given:
+        def docsDir = file("docs")
+        file("docs/guide/index.html").text = '<a href="configurationreference.html#missing">Missing Fragment</a>'
+        file("docs/guide/configurationreference.html").text = '<h1 id="config-reference">Configuration Reference</h1>'
+        def task = task(docsDir, file("docs/guide/index.html"), file("docs/guide/configurationreference.html"))
+
+        when:
+        task.validate()
+
+        then:
+        thrown(GradleException)
+        file("report.txt").text.contains("guide/index.html: link 'configurationreference.html#missing' missing fragment #missing")
+    }
+
+    private ValidateGuideLinksTask task(File docsDir, File... htmlFiles) {
+        def project = ProjectBuilder.builder()
+                .withProjectDir(testDirectory.toFile())
+                .build()
+        def task = project.tasks.register("validateGuideLinks", ValidateGuideLinksTask).get()
+        task.docsDirectory.set(docsDir)
+        task.htmlFiles.from(htmlFiles)
+        task.report.set(file("report.txt"))
+        task
+    }
+
+    private File file(String path) {
+        def file = testDirectory.resolve(path).toFile()
+        file.parentFile.mkdirs()
+        file
+    }
+}


### PR DESCRIPTION
## Summary

- Add a `checkDocsLinks` Gradle task for Micronaut docs projects.
- Validate local file and fragment links in generated `index.html` and `configurationreference.html`.
- Keep `docs` unchanged so CI can invoke link checking explicitly.

## Verification

- `./gradlew :micronaut-gradle-plugins:test --tests io.micronaut.build.docs.ValidateGuideLinksTaskSpec`
- `./gradlew :micronaut-gradle-plugins:functionalTest --tests io.micronaut.build.docs.DocsLinksFunctionalTest`
- `git diff --check origin/HEAD...HEAD`

Closes #181

---
###### ✨ This message was AI-generated using gpt-5.5
