### PR TITLE
Automate GraalVM support list updates

### DIFF
--- a/.github/workflows/update-graalvm-reachability-metadata.yml
+++ b/.github/workflows/update-graalvm-reachability-metadata.yml
@@ -42,6 +42,15 @@ jobs:
           release_version="${DISPATCH_RELEASE_VERSION:-$RELEASE_TAG}"
           release_version="${release_version#v}"
           echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
+      - name: Validate GraalVM reachability metadata token
+        env:
+          GRAALVM_REACHABILITY_METADATA_TOKEN: ${{ secrets.GRAALVM_REACHABILITY_METADATA_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          if [ -z "$GRAALVM_REACHABILITY_METADATA_TOKEN" ] && [ -z "$GH_TOKEN" ]; then
+            echo "GRAALVM_REACHABILITY_METADATA_TOKEN or GH_TOKEN is required to open a PR against oracle/graalvm-reachability-metadata." >&2
+            exit 1
+          fi
       - name: Generate Micronaut entries
         run: ./gradlew generateGraalVmReachabilityMetadata -PgraalVmReachabilityMetadataVersion="${{ steps.release_version.outputs.release_version }}"
       - name: Checkout GraalVM reachability metadata

--- a/.github/workflows/update-graalvm-reachability-metadata.yml
+++ b/.github/workflows/update-graalvm-reachability-metadata.yml
@@ -1,0 +1,70 @@
+name: Update GraalVM Reachability Metadata
+on:
+  release:
+    types: [published]
+  workflow_call:
+    inputs:
+      release_version:
+        description: The Micronaut release version to publish in the GraalVM metadata list.
+        required: true
+        type: string
+    secrets:
+      GRAALVM_REACHABILITY_METADATA_TOKEN:
+        required: false
+      GH_TOKEN:
+        required: false
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: The Micronaut release version to publish in the GraalVM metadata list.
+        required: true
+permissions:
+  contents: read
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Micronaut Build
+        uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Determine release version
+        id: release_version
+        env:
+          DISPATCH_RELEASE_VERSION: ${{ inputs.release_version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          release_version="${DISPATCH_RELEASE_VERSION:-$RELEASE_TAG}"
+          release_version="${release_version#v}"
+          echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
+      - name: Generate Micronaut entries
+        run: ./gradlew generateGraalVmReachabilityMetadata -PgraalVmReachabilityMetadataVersion="${{ steps.release_version.outputs.release_version }}"
+      - name: Checkout GraalVM reachability metadata
+        uses: actions/checkout@v4
+        with:
+          repository: oracle/graalvm-reachability-metadata
+          token: ${{ secrets.GRAALVM_REACHABILITY_METADATA_TOKEN || secrets.GH_TOKEN }}
+          path: graalvm-reachability-metadata
+      - name: Merge Micronaut entries
+        run: |
+          jq -s '.[0] as $current | .[1] as $updates | ($updates | map(.artifact)) as $updatedArtifacts | (($current | map(select(.artifact as $artifact | ($updatedArtifacts | index($artifact)) == null))) + $updates | sort_by(.artifact))' \
+            graalvm-reachability-metadata/metadata/library-and-framework-list.json \
+            build/graalvm-reachability-metadata/library-and-framework-list.json \
+            > graalvm-reachability-metadata/metadata/library-and-framework-list.updated.json
+          mv graalvm-reachability-metadata/metadata/library-and-framework-list.updated.json graalvm-reachability-metadata/metadata/library-and-framework-list.json
+      - name: Create GraalVM reachability metadata pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GRAALVM_REACHABILITY_METADATA_TOKEN || secrets.GH_TOKEN }}
+          path: graalvm-reachability-metadata
+          branch: update-micronaut-build-${{ steps.release_version.outputs.release_version }}
+          delete-branch: true
+          title: Update Micronaut Build GraalVM support list for ${{ steps.release_version.outputs.release_version }}
+          commit-message: Update Micronaut Build GraalVM support list for ${{ steps.release_version.outputs.release_version }}
+          body: |
+            Updates the Micronaut Build entries in `metadata/library-and-framework-list.json` for release `${{ steps.release_version.outputs.release_version }}`.

--- a/buildSrc/src/main/kotlin/io.micronaut.build.internal.parent.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.micronaut.build.internal.parent.gradle.kts
@@ -19,3 +19,126 @@ nexusPublishing {
         }
     }
 }
+
+val graalVmReachabilityMetadataVersion = providers.gradleProperty("graalVmReachabilityMetadataVersion")
+    .orElse(provider { version.toString().removePrefix("v") })
+val graalVmReachabilityMetadataOutput = layout.buildDirectory.file("graalvm-reachability-metadata/library-and-framework-list.json")
+val graalVmReachabilityMetadataTestsLocations = providers.gradleProperty("graalVmReachabilityMetadataTestsLocations")
+    .map { locations ->
+        locations.split(",")
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+    }
+    .orElse(emptyList())
+
+val generateGraalVmReachabilityMetadata by tasks.registering {
+    description = "Generates Micronaut Build entries for GraalVM reachability metadata's library-and-framework list."
+    group = "release"
+    val moduleDescriptions = provider {
+        subprojects
+            .filter { project ->
+                !project.name.contains("bom") &&
+                    !project.name.startsWith("test-suite") &&
+                    project.subprojects.isEmpty() &&
+                    project.plugins.hasPlugin("maven-publish")
+            }
+            .associate { project ->
+                "${project.group}:${moduleNameOf(project.name)}" to (project.description ?: moduleNameOf(project.name))
+            }
+            .toSortedMap()
+    }
+    inputs.property("minimumVersion", graalVmReachabilityMetadataVersion)
+    inputs.property("moduleDescriptions", moduleDescriptions)
+    inputs.property("testsLocations", graalVmReachabilityMetadataTestsLocations)
+    outputs.file(graalVmReachabilityMetadataOutput)
+
+    doLast {
+        val outputFile = graalVmReachabilityMetadataOutput.get().asFile
+        outputFile.parentFile.mkdirs()
+        outputFile.writeText(
+            renderGraalVmReachabilityMetadataEntries(
+                moduleDescriptions.get(),
+                graalVmReachabilityMetadataVersion.get(),
+                graalVmReachabilityMetadataTestsLocations.get()
+            ),
+            Charsets.UTF_8
+        )
+    }
+}
+
+tasks.register("verifyGraalVmReachabilityMetadata") {
+    description = "Verifies Micronaut Build's generated GraalVM reachability metadata evidence locations."
+    group = "verification"
+    dependsOn(generateGraalVmReachabilityMetadata)
+    inputs.file(graalVmReachabilityMetadataOutput)
+
+    doLast {
+        val outputText = graalVmReachabilityMetadataOutput.get().asFile.readText(Charsets.UTF_8)
+        val legacyGraalVmWorkflowUrl = "https://github.com/micronaut-projects/micronaut-build/actions/workflows/graalvm.yml"
+        if (outputText.contains(legacyGraalVmWorkflowUrl) && !file(".github/workflows/graalvm.yml").isFile) {
+            throw GradleException("Generated GraalVM metadata points to missing workflow .github/workflows/graalvm.yml")
+        }
+        if (graalVmReachabilityMetadataTestsLocations.get().isEmpty() && !outputText.contains("\"tests_locations\": []")) {
+            throw GradleException("Generated GraalVM metadata must omit Micronaut Build test evidence until a valid native-test workflow exists")
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn("verifyGraalVmReachabilityMetadata")
+}
+
+fun renderGraalVmReachabilityMetadataEntries(
+    moduleDescriptions: Map<String, String>,
+    minimumVersion: String,
+    testsLocations: List<String>
+): String {
+    return buildString {
+        append("[\n")
+        moduleDescriptions.entries.forEachIndexed { index, entry ->
+            append("  {\n")
+            append("    \"artifact\": \"").append(escapeJson(entry.key)).append("\",\n")
+            append("    \"description\": \"").append(escapeJson(entry.value)).append("\",\n")
+            append("    \"details\": [\n")
+            append("      {\n")
+            append("        \"minimum_version\": \"").append(escapeJson(minimumVersion)).append("\",\n")
+            append("        \"metadata_locations\": [],\n")
+            append("        \"tests_locations\": ").append(renderJsonStringArray(testsLocations)).append(",\n")
+            append("        \"test_level\": \"community-tested\"\n")
+            append("      }\n")
+            append("    ]\n")
+            append("  }")
+            if (index + 1 < moduleDescriptions.size) {
+                append(",")
+            }
+            append("\n")
+        }
+        append("]\n")
+    }
+}
+
+fun renderJsonStringArray(values: List<String>): String = values.joinToString(prefix = "[", postfix = "]") {
+    "\"${escapeJson(it)}\""
+}
+
+fun moduleNameOf(projectName: String): String =
+    if (projectName.startsWith("micronaut-")) projectName else "micronaut-$projectName"
+
+fun escapeJson(value: String): String = buildString {
+    value.forEach { char ->
+        when (char) {
+            '"' -> append("\\\"")
+            '\\' -> append("\\\\")
+            '\b' -> append("\\b")
+            '\u000C' -> append("\\f")
+            '\n' -> append("\\n")
+            '\r' -> append("\\r")
+            '\t' -> append("\\t")
+            else -> if (char < ' ') {
+                append("\\u").append(char.code.toString(16).padStart(4, '0'))
+            } else {
+                append(char)
+            }
+        }
+    }
+}

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautParentPlugin.java
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautParentPlugin.java
@@ -15,18 +15,85 @@
  */
 package io.micronaut.build;
 
+import io.micronaut.build.graalvm.GenerateGraalVmReachabilityMetadataTask;
+import io.micronaut.build.graalvm.GraalVmReachabilityMetadataExtension;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A plugin to be applied on the root project of a multi-project Micronaut project.
  */
 public class MicronautParentPlugin implements Plugin<Project> {
+    public static final String GRAALVM_REACHABILITY_METADATA_EXTENSION_NAME = "graalVmReachabilityMetadata";
+    public static final String GENERATE_GRAALVM_REACHABILITY_METADATA_TASK_NAME = "generateGraalVmReachabilityMetadata";
+
     @Override
     public void apply(Project p) {
         var pluginManager = p.getPluginManager();
+        pluginManager.apply(MicronautBuildExtensionPlugin.class);
         pluginManager.apply("io.micronaut.build.internal.docs");
         pluginManager.apply("io.micronaut.build.internal.quality-reporting");
         pluginManager.apply("io.micronaut.build.internal.parent-publishing");
+        configureGraalVmReachabilityMetadata(p);
+    }
+
+    private static void configureGraalVmReachabilityMetadata(Project project) {
+        var extension = project.getExtensions().create(
+            GRAALVM_REACHABILITY_METADATA_EXTENSION_NAME,
+            GraalVmReachabilityMetadataExtension.class
+        );
+        extension.getMinimumVersion().convention(project.getProviders()
+            .gradleProperty("graalVmReachabilityMetadataVersion")
+            .orElse(project.provider(() -> normalizeVersion(String.valueOf(project.getVersion())))));
+        extension.getTestWorkflowName().convention("graalvm.yml");
+        extension.getTestLevel().convention("community-tested");
+        extension.getMetadataLocations().convention(List.of());
+        extension.getTestsLocations().convention(project.getProviders()
+            .gradleProperty("githubSlug")
+            .map(slug -> List.of("https://github.com/" + slug + "/actions/workflows/" + extension.getTestWorkflowName().get()))
+            .orElse(List.of()));
+        extension.getExcludedProjectNames().convention(List.of());
+
+        project.getTasks().register(GENERATE_GRAALVM_REACHABILITY_METADATA_TASK_NAME, GenerateGraalVmReachabilityMetadataTask.class, task -> {
+            task.getModuleDescriptions().set(project.provider(() -> collectReachabilityMetadataModules(project, extension)));
+            task.getMinimumVersion().convention(extension.getMinimumVersion());
+            task.getMetadataLocations().convention(extension.getMetadataLocations());
+            task.getTestsLocations().convention(extension.getTestsLocations());
+            task.getTestLevel().convention(extension.getTestLevel());
+            task.getOutputFile().convention(project.getLayout().getBuildDirectory().file("graalvm-reachability-metadata/library-and-framework-list.json"));
+        });
+    }
+
+    private static Map<String, String> collectReachabilityMetadataModules(Project root, GraalVmReachabilityMetadataExtension extension) {
+        var modules = new LinkedHashMap<String, String>();
+        var excludedProjectNames = extension.getExcludedProjectNames().get();
+        for (Project project : root.getSubprojects()) {
+            if (excludedProjectNames.contains(project.getName()) || isExcludedProject(project)) {
+                continue;
+            }
+            if (project.getPlugins().hasPlugin(MicronautPublishingPlugin.class) || project.getPlugins().hasPlugin("maven-publish")) {
+                var artifactId = MicronautPlugin.moduleNameOf(project.getName());
+                var description = project.getDescription();
+                modules.put(project.getGroup() + ":" + artifactId, description == null || description.isBlank() ? artifactId : description);
+            }
+        }
+        return modules;
+    }
+
+    private static boolean isExcludedProject(Project project) {
+        return project.getName().contains("bom")
+            || project.getName().startsWith(MicronautPlugin.TEST_SUITE_PROJECT_PREFIX)
+            || !project.getSubprojects().isEmpty();
+    }
+
+    private static String normalizeVersion(String version) {
+        if (version.startsWith("v") && version.length() > 1 && Character.isDigit(version.charAt(1))) {
+            return version.substring(1);
+        }
+        return version;
     }
 }

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautParentPlugin.java
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautParentPlugin.java
@@ -54,7 +54,8 @@ public class MicronautParentPlugin implements Plugin<Project> {
         extension.getMetadataLocations().convention(List.of());
         extension.getTestsLocations().convention(project.getProviders()
             .gradleProperty("githubSlug")
-            .map(slug -> List.of("https://github.com/" + slug + "/actions/workflows/" + extension.getTestWorkflowName().get()))
+            .flatMap(slug -> extension.getTestWorkflowName()
+                .map(testWorkflowName -> List.of("https://github.com/" + slug + "/actions/workflows/" + testWorkflowName)))
             .orElse(List.of()));
         extension.getExcludedProjectNames().convention(List.of());
 
@@ -71,7 +72,10 @@ public class MicronautParentPlugin implements Plugin<Project> {
     private static Map<String, String> collectReachabilityMetadataModules(Project root, GraalVmReachabilityMetadataExtension extension) {
         var modules = new LinkedHashMap<String, String>();
         var excludedProjectNames = extension.getExcludedProjectNames().get();
-        for (Project project : root.getSubprojects()) {
+        for (Project project : root.getAllprojects()) {
+            if (project == root) {
+                continue;
+            }
             if (excludedProjectNames.contains(project.getName()) || isExcludedProject(project)) {
                 continue;
             }

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/graalvm/GenerateGraalVmReachabilityMetadataTask.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/graalvm/GenerateGraalVmReachabilityMetadataTask.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.graalvm;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generates Micronaut entries for GraalVM reachability metadata's library-and-framework list.
+ */
+@CacheableTask
+public abstract class GenerateGraalVmReachabilityMetadataTask extends DefaultTask {
+    @Input
+    public abstract MapProperty<String, String> getModuleDescriptions();
+
+    @Input
+    public abstract Property<String> getMinimumVersion();
+
+    @Input
+    public abstract ListProperty<String> getMetadataLocations();
+
+    @Input
+    public abstract ListProperty<String> getTestsLocations();
+
+    @Input
+    public abstract Property<String> getTestLevel();
+
+    @OutputFile
+    public abstract RegularFileProperty getOutputFile();
+
+    public GenerateGraalVmReachabilityMetadataTask() {
+        setDescription("Generates Micronaut entries for GraalVM reachability metadata's library-and-framework list.");
+        setGroup("release");
+    }
+
+    @TaskAction
+    public void generate() throws IOException {
+        var outputFile = getOutputFile().get().getAsFile().toPath();
+        Files.createDirectories(outputFile.getParent());
+        Files.writeString(outputFile, renderEntries(), StandardCharsets.UTF_8);
+    }
+
+    private String renderEntries() {
+        var entries = new ArrayList<>(getModuleDescriptions().get().entrySet());
+        entries.sort(Comparator.comparing(Map.Entry::getKey));
+
+        var json = new StringBuilder();
+        json.append("[\n");
+        for (int i = 0; i < entries.size(); i++) {
+            var entry = entries.get(i);
+            json.append("  {\n");
+            json.append("    \"artifact\": \"").append(escapeJson(entry.getKey())).append("\",\n");
+            json.append("    \"description\": \"").append(escapeJson(entry.getValue())).append("\",\n");
+            json.append("    \"details\": [\n");
+            json.append("      {\n");
+            json.append("        \"minimum_version\": \"").append(escapeJson(getMinimumVersion().get())).append("\",\n");
+            json.append("        \"metadata_locations\": ");
+            appendStringArray(json, getMetadataLocations().get());
+            json.append(",\n");
+            json.append("        \"tests_locations\": ");
+            appendStringArray(json, getTestsLocations().get());
+            json.append(",\n");
+            json.append("        \"test_level\": \"").append(escapeJson(getTestLevel().get())).append("\"\n");
+            json.append("      }\n");
+            json.append("    ]\n");
+            json.append("  }");
+            if (i + 1 < entries.size()) {
+                json.append(",");
+            }
+            json.append("\n");
+        }
+        json.append("]\n");
+        return json.toString();
+    }
+
+    private static void appendStringArray(StringBuilder json, List<String> values) {
+        json.append("[");
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                json.append(", ");
+            }
+            json.append("\"").append(escapeJson(values.get(i))).append("\"");
+        }
+        json.append("]");
+    }
+
+    private static String escapeJson(String value) {
+        var escaped = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"' -> escaped.append("\\\"");
+                case '\\' -> escaped.append("\\\\");
+                case '\b' -> escaped.append("\\b");
+                case '\f' -> escaped.append("\\f");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        escaped.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        escaped.append(c);
+                    }
+                }
+            }
+        }
+        return escaped.toString();
+    }
+}

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/graalvm/GraalVmReachabilityMetadataExtension.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/graalvm/GraalVmReachabilityMetadataExtension.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.build.graalvm;
+
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+
+/**
+ * Configures the GraalVM reachability metadata library list generated for releases.
+ */
+public interface GraalVmReachabilityMetadataExtension {
+    /**
+     * The minimum released version to report for generated entries.
+     * @return the minimum version
+     */
+    Property<String> getMinimumVersion();
+
+    /**
+     * The workflow file name used for the default tests location.
+     * @return the workflow file name
+     */
+    Property<String> getTestWorkflowName();
+
+    /**
+     * The test level to report for generated entries.
+     * @return the test level
+     */
+    Property<String> getTestLevel();
+
+    /**
+     * Metadata locations to report for every generated entry.
+     * @return the metadata locations
+     */
+    ListProperty<String> getMetadataLocations();
+
+    /**
+     * Test locations to report for every generated entry.
+     * @return the test locations
+     */
+    ListProperty<String> getTestsLocations();
+
+    /**
+     * Additional project names that should not be included in the generated list.
+     * @return excluded project names
+     */
+    SetProperty<String> getExcludedProjectNames();
+}

--- a/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/MicronautParentPluginTest.groovy
+++ b/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/MicronautParentPluginTest.groovy
@@ -1,0 +1,44 @@
+package io.micronaut.build
+
+import io.micronaut.build.graalvm.GraalVmReachabilityMetadataExtension
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class MicronautParentPluginTest extends Specification {
+    def "collects nested published leaf projects for GraalVM reachability metadata"() {
+        given:
+        Project root = ProjectBuilder.builder().withName("root").build()
+        Project aggregator = ProjectBuilder.builder().withName("aggregator").withParent(root).build()
+        Project nested = ProjectBuilder.builder().withName("nested-module").withParent(aggregator).build()
+        Project direct = ProjectBuilder.builder().withName("direct-module").withParent(root).build()
+        [aggregator, nested, direct].each {
+            it.group = "io.micronaut.test"
+            it.description = "Description for $it.name"
+        }
+        nested.plugins.apply("maven-publish")
+        direct.plugins.apply("maven-publish")
+
+        def extension = root.extensions.create("graalVmReachabilityMetadata", GraalVmReachabilityMetadataExtension)
+        extension.excludedProjectNames.convention([] as Set<String>)
+
+        when:
+        Map<String, String> modules = collectReachabilityMetadataModules(root, extension)
+
+        then:
+        modules == [
+            "io.micronaut.test:micronaut-direct-module": "Description for direct-module",
+            "io.micronaut.test:micronaut-nested-module": "Description for nested-module"
+        ]
+    }
+
+    private static Map<String, String> collectReachabilityMetadataModules(Project root, GraalVmReachabilityMetadataExtension extension) {
+        def method = MicronautParentPlugin.getDeclaredMethod(
+            "collectReachabilityMetadataModules",
+            Project,
+            GraalVmReachabilityMetadataExtension
+        )
+        method.accessible = true
+        method.invoke(null, root, extension) as Map<String, String>
+    }
+}

--- a/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/graalvm/GenerateGraalVmReachabilityMetadataTaskTest.groovy
+++ b/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/graalvm/GenerateGraalVmReachabilityMetadataTaskTest.groovy
@@ -1,0 +1,71 @@
+package io.micronaut.build.graalvm
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class GenerateGraalVmReachabilityMetadataTaskTest extends Specification {
+    private Project project
+    private GenerateGraalVmReachabilityMetadataTask task
+    private File generatedOutputFile
+
+    def setup() {
+        project = ProjectBuilder.builder().build()
+        generatedOutputFile = project.layout.buildDirectory.file("metadata/library-and-framework-list.json").get().asFile
+        task = project.tasks.create("generateReachabilityMetadata", GenerateGraalVmReachabilityMetadataTask) {
+            minimumVersion.set("4.8.0")
+            metadataLocations.set([])
+            testsLocations.set(["https://github.com/micronaut-projects/micronaut-test/actions/workflows/graalvm.yml"])
+            testLevel.set("community-tested")
+            moduleDescriptions.put("io.micronaut.test:micronaut-test-core", "Micronaut Test Core")
+            moduleDescriptions.put("io.micronaut.test:micronaut-test-junit5", "Micronaut Test JUnit 5")
+        }
+        task.outputFile.set(generatedOutputFile)
+    }
+
+    def "generates library and framework list entries"() {
+        when:
+        task.generate()
+
+        then:
+        generatedOutputFile.text == """[
+  {
+    "artifact": "io.micronaut.test:micronaut-test-core",
+    "description": "Micronaut Test Core",
+    "details": [
+      {
+        "minimum_version": "4.8.0",
+        "metadata_locations": [],
+        "tests_locations": ["https://github.com/micronaut-projects/micronaut-test/actions/workflows/graalvm.yml"],
+        "test_level": "community-tested"
+      }
+    ]
+  },
+  {
+    "artifact": "io.micronaut.test:micronaut-test-junit5",
+    "description": "Micronaut Test JUnit 5",
+    "details": [
+      {
+        "minimum_version": "4.8.0",
+        "metadata_locations": [],
+        "tests_locations": ["https://github.com/micronaut-projects/micronaut-test/actions/workflows/graalvm.yml"],
+        "test_level": "community-tested"
+      }
+    ]
+  }
+]
+"""
+    }
+
+    def "escapes json strings"() {
+        given:
+        task.moduleDescriptions.empty()
+        task.moduleDescriptions.put("io.micronaut.test:micronaut-json", "Line one\n\"quoted\"")
+
+        when:
+        task.generate()
+
+        then:
+        generatedOutputFile.text.contains('"description": "Line one\\n\\"quoted\\""')
+    }
+}


### PR DESCRIPTION
## Summary
- add a GraalVM reachability metadata generator to the Micronaut parent build plugin
- add Micronaut Build release automation to update Oracle's `metadata/library-and-framework-list.json`
- verify this repository emits empty `tests_locations` until a valid native-test evidence workflow exists

## Verification
- `./gradlew generateGraalVmReachabilityMetadata verifyGraalVmReachabilityMetadata -PgraalVmReachabilityMetadataVersion=8.0.0`
- `./gradlew :micronaut-gradle-plugins:test --tests 'io.micronaut.build.graalvm.*'`
- `git diff --check origin/8.0.x...HEAD`

## Release Metadata
- Type: `type: enhancement`
- Target branch: `8.0.x`
- Micronaut organization projects: no matching open project for the `8.0.0` target was visible through `gh project list`; no project link was applied.

Fixes #535

---
###### ✨ This message was AI-generated using gpt-5