### PR TITLE
Track snippet sources for publishGuide

### DIFF
--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/docs/PublishGuideTaskFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/docs/PublishGuideTaskFunctionalTest.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.build.docs
+
+import io.micronaut.build.AbstractFunctionalTest
+import org.gradle.testkit.runner.TaskOutcome
+
+import java.nio.file.Files
+
+class PublishGuideTaskFunctionalTest extends AbstractFunctionalTest {
+
+    void "snippet source changes invalidate publishGuide"() {
+        given:
+        withSample("test-micronaut-module")
+        copyDocResourcesJar()
+        file("src/main/docs/guide/introduction.adoc").text = "snippet::example.Hello[tags=body]\n"
+        def snippet = file("test-suite/src/test/java/example/Hello.java")
+        snippet.text = snippetSource("one")
+
+        when:
+        run "publishGuide"
+
+        then:
+        result.task(":publishGuide").outcome == TaskOutcome.SUCCESS
+        guideHtml.contains('return "one";')
+
+        when:
+        snippet.text = snippetSource("two")
+        run "publishGuide"
+
+        then:
+        result.task(":publishGuide").outcome == TaskOutcome.SUCCESS
+        guideHtml.contains('return "two";')
+        !guideHtml.contains('return "one";')
+    }
+
+    private String getGuideHtml() {
+        testDirectory.resolve("build/working/02-docs-raw/all/guide/introduction.html").text
+    }
+
+    private void copyDocResourcesJar() {
+        def path = Files.createDirectories(testDirectory.resolve("build/tmp/prepareDocsResources"))
+        def stream = PublishGuideTaskFunctionalTest.getResourceAsStream("/grails-doc-files.jar")
+        def target = path.resolve("grails-doc-files.jar")
+        Files.copy(stream, target)
+    }
+
+    private static String snippetSource(String value) {
+        """
+package example;
+
+class Hello {
+    // tag::body[]
+    String value() {
+        return "${value}";
+    }
+    // end::body[]
+}
+""".stripIndent()
+    }
+}

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/docs/PublishGuideTask.java
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/docs/PublishGuideTask.java
@@ -16,6 +16,7 @@
 package io.micronaut.build.docs;
 
 import io.micronaut.docs.DocPublisher;
+import io.micronaut.docs.SnippetSourceResolver;
 import io.micronaut.docs.macros.HiddenMacro;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -26,6 +27,7 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.IgnoreEmptyDirectories;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFiles;
@@ -40,6 +42,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.Set;
 
 @CacheableTask
 public abstract class PublishGuideTask extends DefaultTask {
@@ -59,6 +62,11 @@ public abstract class PublishGuideTask extends DefaultTask {
     @InputFiles
     @PathSensitive(PathSensitivity.NAME_ONLY)
     public abstract ConfigurableFileCollection getPropertiesFiles();
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @IgnoreEmptyDirectories
+    public abstract ConfigurableFileCollection getSnippetSourceFiles();
 
     @Input
     @Optional
@@ -86,12 +94,21 @@ public abstract class PublishGuideTask extends DefaultTask {
         getTargetDir().convention(buildDirectory.dir("docs"));
         getResourcesDir().convention(projectDirectory.dir("resources"));
         getAsciidoc().convention(false);
+        getSnippetSourceFiles().from(getProject().provider(this::resolveSnippetSourceFiles));
     }
 
     private static void loadProperties(Properties into, File src) throws IOException {
         try (FileInputStream fis = new FileInputStream(src)) {
             into.load(fis);
         }
+    }
+
+    private Set<File> resolveSnippetSourceFiles() {
+        return SnippetSourceResolver.findSnippetSourceFiles(
+            getSourceDir().get().getAsFile(),
+            getProject().getProjectDir(),
+            getLanguage().getOrElse("")
+        );
     }
 
     @TaskAction

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
@@ -15,41 +15,16 @@ public class LanguageSnippetMacro extends BlockMacroProcessor implements ValueAt
     private static final String LANG_KOTLIN = 'kotlin'
     private static final String LANG_PYTHON = 'python'
     public static final List<String> LANGS = [LANG_JAVA, LANG_PYTHON, LANG_KOTLIN, LANG_GROOVY]
-    private static final String DEFAULT_KOTLIN_PROJECT = 'test-suite-kotlin'
-    private static final String DEFAULT_PYTHON_PROJECT = 'test-suite-python'
-    private static final String DEFAULT_JAVA_PROJECT = 'test-suite'
-    private static final String DEFAULT_GROOVY_PROJECT = 'test-suite-groovy'
-    private static final String ATTR_PROJECT = 'project'
-    private static final String ATTR_SOURCE = 'source'
-    private static final String ATTR_PROJECT_BASE = 'project-base'
 
     LanguageSnippetMacro(String macroName, Map<String, Object> config, Asciidoctor asciidoctor) {
         super(macroName, config)
         this.asciidoctor = asciidoctor
     }
 
-    private String projectDir(String lang, Map<String, Object> attributes) {
-        String projectBase = valueAtAttributes(ATTR_PROJECT_BASE, attributes)
-        if (projectBase) {
-            return "$projectBase-$lang"
-        }
-
-        String project = valueAtAttributes(ATTR_PROJECT, attributes)
-        if (project) {
-            return project
-        } else {
-            if (lang == LANG_KOTLIN) {
-                return DEFAULT_KOTLIN_PROJECT
-            }
-            else if (lang == LANG_PYTHON) {
-                return DEFAULT_PYTHON_PROJECT
-            }
-            if (lang == LANG_GROOVY) {
-                return DEFAULT_GROOVY_PROJECT
-            } else {
-                return DEFAULT_JAVA_PROJECT
-            }
-        }
+    private File snippetFile(StructuralNode parent, String lang, String fileName, Map<String, Object> attributes) {
+        String sourceDir = parent.document.getAttribute('sourcedir') ?: parent.document.getAttribute('sourceDir')
+        File baseDir = sourceDir ? new File(sourceDir) : System.getProperty("user.dir") ? new File(System.getProperty("user.dir")) : new File("")
+        SnippetSourceResolver.resolveSnippetFile(baseDir, lang, fileName, attributes)
     }
 
     @Override
@@ -74,31 +49,10 @@ public class LanguageSnippetMacro extends BlockMacroProcessor implements ValueAt
         String[] files = target.split(",")
         for (lang in languagesToRender) {
             if (title != null) content << ".$title\n\n"
-            String projectDir = projectDir(lang, attributes)
-            String ext
-
-            if(lang == LANG_KOTLIN)
-                ext = 'kt'
-            else if (lang == LANG_PYTHON)
-                ext = 'py'
-            else
-                ext = lang
-            String sourceFolder = lang
-            String sourceType = valueAtAttributes(ATTR_SOURCE, attributes) ?: 'test'
 
             List includes = []
             for (fileName in files) {
-                String baseName = fileName.replace(".", File.separator)
-                // io is an internal package for Python
-                if (lang == LANG_PYTHON && baseName.startsWith("io/")) {
-                    baseName = baseName.substring(3)
-                }
-
-                String pathName = "$projectDir/src/$sourceType/$sourceFolder/${baseName}.$ext"
-                if (System.getProperty("user.dir") != null) {
-                    pathName = "${System.getProperty("user.dir")}${File.separator}${pathName}".toString()
-                }
-                File file = new File(pathName)
+                File file = snippetFile(parent, lang, fileName, attributes)
                 if (!file.exists()) {
                     println "!!!! WARNING: NO FILE FOUND MATCHING TARGET PASSED IN AT PATH : $file.path"
                     continue

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/SnippetSourceResolver.java
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/SnippetSourceResolver.java
@@ -1,0 +1,206 @@
+package io.micronaut.docs;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public final class SnippetSourceResolver {
+
+    private static final String LANG_JAVA = "java";
+    private static final String LANG_GROOVY = "groovy";
+    private static final String LANG_KOTLIN = "kotlin";
+    private static final String LANG_PYTHON = "python";
+    private static final List<String> LANGS = List.of(LANG_JAVA, LANG_PYTHON, LANG_KOTLIN, LANG_GROOVY);
+    private static final String DEFAULT_KOTLIN_PROJECT = "test-suite-kotlin";
+    private static final String DEFAULT_PYTHON_PROJECT = "test-suite-python";
+    private static final String DEFAULT_JAVA_PROJECT = "test-suite";
+    private static final String DEFAULT_GROOVY_PROJECT = "test-suite-groovy";
+    private static final String ATTR_PROJECT = "project";
+    private static final String ATTR_SOURCE = "source";
+    private static final String ATTR_PROJECT_BASE = "project-base";
+    private static final Pattern SNIPPET_MACRO = Pattern.compile("(?m)^\\s*snippet::([^\\[]+)\\[([^\\]]*)]");
+
+    private SnippetSourceResolver() {
+    }
+
+    public static List<String> languagesToRender(String defaultLanguage) {
+        if (defaultLanguage != null && LANGS.contains(defaultLanguage)) {
+            return List.of(defaultLanguage);
+        }
+        return LANGS;
+    }
+
+    public static Set<File> findSnippetSourceFiles(File sourceDir, File baseDir, String defaultLanguage) {
+        if (!sourceDir.isDirectory()) {
+            return Collections.emptySet();
+        }
+        Set<File> result = new LinkedHashSet<>();
+        try (Stream<Path> paths = Files.walk(sourceDir.toPath())) {
+            paths.filter(Files::isRegularFile)
+                .filter(SnippetSourceResolver::isAsciiDoc)
+                .forEach(path -> result.addAll(findSnippetSourceFiles(path, baseDir, defaultLanguage)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return result;
+    }
+
+    public static Set<File> findSnippetSourceFiles(Path asciiDoc, File baseDir, String defaultLanguage) {
+        String content;
+        try {
+            content = Files.readString(asciiDoc, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        Set<File> result = new LinkedHashSet<>();
+        Matcher matcher = SNIPPET_MACRO.matcher(content);
+        while (matcher.find()) {
+            String target = matcher.group(1);
+            Map<String, Object> attributes = parseAttributes(matcher.group(2));
+            for (String language : languagesToRender(defaultLanguage)) {
+                for (String fileName : splitTargets(target)) {
+                    File snippetFile = resolveSnippetFile(baseDir, language, fileName, attributes);
+                    if (snippetFile.exists()) {
+                        result.add(snippetFile);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    public static File resolveSnippetFile(File baseDir, String language, String fileName, Map<String, Object> attributes) {
+        String baseName = fileName.trim().replace(".", File.separator);
+        if (LANG_PYTHON.equals(language) && baseName.startsWith("io" + File.separator)) {
+            baseName = baseName.substring(3);
+        }
+        return new File(baseDir, projectDir(language, attributes)
+            + File.separator + "src"
+            + File.separator + sourceType(attributes)
+            + File.separator + language
+            + File.separator + baseName + "." + extension(language));
+    }
+
+    private static List<String> splitTargets(String target) {
+        String[] targets = target.split(",");
+        List<String> result = new ArrayList<>(targets.length);
+        for (String current : targets) {
+            String trimmed = current.trim();
+            if (!trimmed.isEmpty()) {
+                result.add(trimmed);
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, Object> parseAttributes(String attributes) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (String attribute : splitAttributes(attributes)) {
+            int equals = attribute.indexOf('=');
+            if (equals < 0) {
+                continue;
+            }
+            String key = attribute.substring(0, equals).trim();
+            String value = attribute.substring(equals + 1).trim();
+            if (!key.isEmpty()) {
+                result.put(key, unquote(value));
+            }
+        }
+        return result;
+    }
+
+    private static List<String> splitAttributes(String attributes) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        char quote = 0;
+        for (int i = 0; i < attributes.length(); i++) {
+            char c = attributes.charAt(i);
+            if ((c == '\'' || c == '"') && quote == 0) {
+                quote = c;
+            } else if (c == quote) {
+                quote = 0;
+            }
+            if (c == ',' && quote == 0) {
+                result.add(current.toString().trim());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        result.add(current.toString().trim());
+        return result;
+    }
+
+    private static String unquote(String value) {
+        if (value.length() >= 2) {
+            char first = value.charAt(0);
+            char last = value.charAt(value.length() - 1);
+            if ((first == '\'' && last == '\'') || (first == '"' && last == '"')) {
+                return value.substring(1, value.length() - 1);
+            }
+        }
+        return value;
+    }
+
+    private static String projectDir(String language, Map<String, Object> attributes) {
+        String projectBase = valueAtAttributes(ATTR_PROJECT_BASE, attributes);
+        if (projectBase != null && !projectBase.isEmpty()) {
+            return projectBase + "-" + language;
+        }
+
+        String project = valueAtAttributes(ATTR_PROJECT, attributes);
+        if (project != null && !project.isEmpty()) {
+            return project;
+        }
+        if (LANG_KOTLIN.equals(language)) {
+            return DEFAULT_KOTLIN_PROJECT;
+        }
+        if (LANG_PYTHON.equals(language)) {
+            return DEFAULT_PYTHON_PROJECT;
+        }
+        if (LANG_GROOVY.equals(language)) {
+            return DEFAULT_GROOVY_PROJECT;
+        }
+        return DEFAULT_JAVA_PROJECT;
+    }
+
+    private static String sourceType(Map<String, Object> attributes) {
+        String sourceType = valueAtAttributes(ATTR_SOURCE, attributes);
+        return sourceType == null || sourceType.isEmpty() ? "test" : sourceType;
+    }
+
+    private static String extension(String language) {
+        if (LANG_KOTLIN.equals(language)) {
+            return "kt";
+        }
+        if (LANG_PYTHON.equals(language)) {
+            return "py";
+        }
+        return language;
+    }
+
+    private static String valueAtAttributes(String name, Map<String, Object> attributes) {
+        Object value = attributes.get(name);
+        return value == null ? null : value.toString();
+    }
+
+    private static boolean isAsciiDoc(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase(Locale.ROOT);
+        return fileName.endsWith(".adoc") || fileName.endsWith(".asciidoc") || fileName.endsWith(".ad");
+    }
+}

--- a/micronaut-gradle-plugins/src/test/groovy/io/micronaut/docs/SnippetSourceResolverSpec.groovy
+++ b/micronaut-gradle-plugins/src/test/groovy/io/micronaut/docs/SnippetSourceResolverSpec.groovy
@@ -1,0 +1,72 @@
+package io.micronaut.docs
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
+
+class SnippetSourceResolverSpec extends Specification {
+
+    @TempDir
+    Path testDirectory
+
+    void "finds snippet source files for aggregate guide"() {
+        given:
+        file("src/main/docs/guide/index.adoc") << "snippet::example.Foo,example.Bar[tags=body]\n"
+        def javaFile = file("test-suite/src/test/java/example/Foo.java")
+        def groovyFile = file("test-suite-groovy/src/test/groovy/example/Foo.groovy")
+        def kotlinFile = file("test-suite-kotlin/src/test/kotlin/example/Foo.kt")
+        def pythonFile = file("test-suite-python/src/test/python/example/Foo.py")
+        def secondJavaFile = file("test-suite/src/test/java/example/Bar.java")
+
+        expect:
+        SnippetSourceResolver.findSnippetSourceFiles(
+                testDirectory.resolve("src/main/docs").toFile(),
+                testDirectory.toFile(),
+                ""
+        ) == [javaFile, secondJavaFile, pythonFile, kotlinFile, groovyFile] as Set
+    }
+
+    void "finds snippet source files for language specific guide"() {
+        given:
+        file("src/main/docs/guide/index.adoc") << "snippet::example.Foo[]\n"
+        file("test-suite/src/test/java/example/Foo.java")
+        def kotlinFile = file("test-suite-kotlin/src/test/kotlin/example/Foo.kt")
+
+        expect:
+        SnippetSourceResolver.findSnippetSourceFiles(
+                testDirectory.resolve("src/main/docs").toFile(),
+                testDirectory.toFile(),
+                "kotlin"
+        ) == [kotlinFile] as Set
+    }
+
+    void "honors snippet project source project base and python package rules"() {
+        given:
+        file("src/main/docs/guide/index.adoc") << """
+snippet::example.Main[project=custom,source=main]
+snippet::io.micronaut.Sample[project-base=base]
+""".stripIndent()
+        def customJavaFile = file("custom/src/main/java/example/Main.java")
+        def baseJavaFile = file("base-java/src/test/java/io/micronaut/Sample.java")
+        def basePythonFile = file("base-python/src/test/python/micronaut/Sample.py")
+        def baseKotlinFile = file("base-kotlin/src/test/kotlin/io/micronaut/Sample.kt")
+        def baseGroovyFile = file("base-groovy/src/test/groovy/io/micronaut/Sample.groovy")
+
+        expect:
+        SnippetSourceResolver.findSnippetSourceFiles(
+                testDirectory.resolve("src/main/docs").toFile(),
+                testDirectory.toFile(),
+                ""
+        ) == [customJavaFile, baseJavaFile, basePythonFile, baseKotlinFile, baseGroovyFile] as Set
+    }
+
+    private File file(String path) {
+        File f = testDirectory.resolve(path).toFile()
+        f.parentFile.mkdirs()
+        if (!f.exists()) {
+            assert f.createNewFile()
+        }
+        return f
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a bounded snippet source resolver for `snippet::` macros under the guide source tree.
- Declares resolved snippet source files as `PublishGuideTask` inputs so source-only snippet edits invalidate `publishGuide`.
- Shares snippet path resolution with `LanguageSnippetMacro` and covers aggregate plus language-specific guide tasks.

## Verification
- `./gradlew --rerun-tasks :micronaut-gradle-plugins:test --tests io.micronaut.docs.SnippetSourceResolverSpec --tests io.micronaut.docs.LanguageSnippetMacroSpec :micronaut-gradle-plugins:functionalTest --tests io.micronaut.build.docs.PublishGuideTaskFunctionalTest`
- `git diff --check 331b641..HEAD`

## Release Metadata
- Type: `type: bug`
- Target branch: `8.0.x`
- Organization projects selected during QA: `5.0.0-M3` and `5.0.0 Release`.
- Project-selection ambiguity: inherited from QA; this is the earliest Micronaut Platform release set likely to consume the `micronaut-build` 8.0.0 line.

Closes #262

---
###### ✨ This message was AI-generated using gpt-5.5
