### PR TITLE
Fix BOM checker handling of repository throttling

### DIFF
--- a/src/main/groovy/io/micronaut/build/pom/PomDownloader.java
+++ b/src/main/groovy/io/micronaut/build/pom/PomDownloader.java
@@ -22,12 +22,20 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -35,14 +43,28 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class PomDownloader {
-    private static Pattern SNAPSHOT_PATTERN = Pattern.compile("<snapshot>.*</snapshot>");
-    private static Pattern ID_PATTERN = Pattern.compile("<timestamp>(.*?)</timestamp><buildNumber>(.*?)</buildNumber>");
+    private static final Pattern SNAPSHOT_PATTERN = Pattern.compile("<snapshot>.*</snapshot>");
+    private static final Pattern ID_PATTERN = Pattern.compile("<timestamp>(.*?)</timestamp><buildNumber>(.*?)</buildNumber>");
+    private static final int DEFAULT_MAX_REMOTE_DOWNLOADS = 4;
+    private static final int DEFAULT_MAX_ATTEMPTS = 6;
+    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = (int) Duration.ofSeconds(30).toMillis();
+    private static final int DEFAULT_READ_TIMEOUT_MILLIS = (int) Duration.ofSeconds(60).toMillis();
+    private static final long DEFAULT_INITIAL_BACKOFF_MILLIS = 1_000L;
+    private static final long DEFAULT_MAX_BACKOFF_MILLIS = 30_000L;
+    private static final String USER_AGENT = "micronaut-build-pom-checker";
+    private static final Semaphore REMOTE_DOWNLOADS = new Semaphore(intProperty(
+        "micronaut.pom.checker.max.remote.downloads",
+        DEFAULT_MAX_REMOTE_DOWNLOADS
+    ));
 
     private final List<String> repositories;
     private final File pomsDirectory;
     private final Lock lock = new ReentrantLock();
     private final Condition condition = lock.newCondition();
     private final Set<String> processing = new HashSet<>();
+    private final int maxAttempts = intProperty("micronaut.pom.checker.download.max.attempts", DEFAULT_MAX_ATTEMPTS);
+    private final int connectTimeoutMillis = intProperty("micronaut.pom.checker.connect.timeout.millis", DEFAULT_CONNECT_TIMEOUT_MILLIS);
+    private final int readTimeoutMillis = intProperty("micronaut.pom.checker.read.timeout.millis", DEFAULT_READ_TIMEOUT_MILLIS);
 
     public PomDownloader(List<String> repositories, File pomDirectory) {
         this.repositories = repositories;
@@ -50,11 +72,21 @@ public class PomDownloader {
     }
 
     public Optional<File> tryDownloadPom(PomDependency dependency) {
-        return repositories.stream()
-                .map(repositoryUrl -> tryDownloadPom(dependency, repositoryUrl))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .findFirst();
+        TransientDownloadException lastTransientFailure = null;
+        for (String repositoryUrl : repositories) {
+            try {
+                Optional<File> pom = tryDownloadPom(dependency, repositoryUrl);
+                if (pom.isPresent()) {
+                    return pom;
+                }
+            } catch (TransientDownloadException e) {
+                lastTransientFailure = e;
+            }
+        }
+        if (lastTransientFailure != null) {
+            throw new GradleException(lastTransientFailure.getMessage(), lastTransientFailure);
+        }
+        return Optional.empty();
     }
 
     private Optional<File> tryDownloadPom(PomDependency dependency, String repositoryUrl) {
@@ -84,25 +116,25 @@ public class PomDownloader {
             }
             processing.add(pomFilePath);
         } catch (InterruptedException e) {
-            throw new GradleException("Unable to download POM at "+ uri, e);
+            Thread.currentThread().interrupt();
+            throw new GradleException("Interrupted while waiting to download POM at " + uri, e);
         } finally {
             lock.unlock();
         }
         try {
-            URL url = new URL(uri);
             File pomFile = new File(pomsDirectory, pomFilePath);
             if (pomFile.exists() && isSnapshot) {
-                pomFile.delete();
+                Files.delete(pomFile.toPath());
             }
             if (!pomFile.exists()) {
-                try (InputStream in = url.openStream()) {
-                    pomFile.getParentFile().mkdirs();
-                    Files.copy(in, pomFile.toPath());
+                DownloadResult result = download(uri, pomFile);
+                if (result == DownloadResult.NOT_FOUND) {
+                    return Optional.empty();
                 }
             }
             return Optional.of(pomFile);
         } catch (IOException e) {
-            return Optional.empty();
+            throw new GradleException("Unable to store POM downloaded from " + uri, e);
         } finally {
             lock.lock();
             try {
@@ -116,9 +148,13 @@ public class PomDownloader {
 
     private Optional<String> findSnapshotVersion(String repositoryUrl, String basedir) {
         String uri = repositoryUrl + basedir + "maven-metadata.xml";
+        File metadataFile = new File(pomsDirectory, basedir + "maven-metadata.xml");
         try {
-            URL url = new URL(uri);
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
+            DownloadResult result = download(uri, metadataFile);
+            if (result == DownloadResult.NOT_FOUND) {
+                return Optional.empty();
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(metadataFile.toPath())))) {
                 StringBuilder sb = new StringBuilder();
                 String line;
                 while ((line = reader.readLine()) != null) {
@@ -135,8 +171,176 @@ public class PomDownloader {
                 }
             }
         } catch (IOException e) {
-            return Optional.empty();
+            throw new GradleException("Unable to read snapshot metadata downloaded from " + uri, e);
         }
         return Optional.empty();
+    }
+
+    private DownloadResult download(String uri, File destination) throws IOException {
+        URI parsedUri = toUri(uri);
+        if (isLocalFile(parsedUri)) {
+            File source = toLocalFile(parsedUri);
+            if (!source.isFile()) {
+                return DownloadResult.NOT_FOUND;
+            }
+            copyAtomically(source, destination);
+            return DownloadResult.DOWNLOADED;
+        }
+
+        URL url = parsedUri.toURL();
+        IOException lastException = null;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            boolean permitAcquired = false;
+            HttpURLConnection connection = null;
+            try {
+                REMOTE_DOWNLOADS.acquire();
+                permitAcquired = true;
+                connection = (HttpURLConnection) url.openConnection();
+                connection.setConnectTimeout(connectTimeoutMillis);
+                connection.setReadTimeout(readTimeoutMillis);
+                connection.setRequestProperty("User-Agent", USER_AGENT);
+                connection.setRequestProperty("Accept", "application/xml,text/xml,*/*;q=0.8");
+                int status = connection.getResponseCode();
+                if (status == HttpURLConnection.HTTP_NOT_FOUND) {
+                    return DownloadResult.NOT_FOUND;
+                }
+                if (status >= 200 && status < 300) {
+                    try (InputStream in = connection.getInputStream()) {
+                        copyAtomically(in, destination);
+                    }
+                    return DownloadResult.DOWNLOADED;
+                }
+                if (isTransientStatus(status)) {
+                    sleepBeforeRetry(uri, attempt, retryAfterMillis(connection), "HTTP " + status);
+                    continue;
+                }
+                return DownloadResult.NOT_FOUND;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new GradleException("Interrupted while downloading POM at " + uri, e);
+            } catch (IOException e) {
+                lastException = e;
+                try {
+                    sleepBeforeRetry(uri, attempt, Optional.empty(), e.getClass().getSimpleName() + ": " + e.getMessage());
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw new GradleException("Interrupted while downloading POM at " + uri, interrupted);
+                }
+            } finally {
+                if (connection != null) {
+                    connection.disconnect();
+                }
+                if (permitAcquired) {
+                    REMOTE_DOWNLOADS.release();
+                }
+            }
+        }
+        throw new TransientDownloadException("Unable to download POM at " + uri + " after " + maxAttempts + " attempts" +
+            (lastException == null ? "" : ": " + lastException.getMessage()), lastException);
+    }
+
+    private void sleepBeforeRetry(String uri, int attempt, Optional<Long> retryAfterMillis, String reason) throws InterruptedException {
+        if (attempt >= maxAttempts) {
+            return;
+        }
+        long backoff = retryAfterMillis.orElseGet(() -> exponentialBackoffWithJitter(attempt));
+        System.err.println("Retrying POM download after " + reason + " (attempt " + attempt + "/" + maxAttempts + "): " + uri);
+        Thread.sleep(backoff);
+    }
+
+    private static long exponentialBackoffWithJitter(int attempt) {
+        long exponential = DEFAULT_INITIAL_BACKOFF_MILLIS << Math.min(attempt - 1, 5);
+        long capped = Math.min(exponential, DEFAULT_MAX_BACKOFF_MILLIS);
+        long jitter = ThreadLocalRandom.current().nextLong(0, Math.max(1L, capped / 4));
+        return capped + jitter;
+    }
+
+    private static Optional<Long> retryAfterMillis(HttpURLConnection connection) {
+        String retryAfter = connection.getHeaderField("Retry-After");
+        if (retryAfter == null || retryAfter.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            long seconds = Long.parseLong(retryAfter.trim());
+            return Optional.of(Math.max(0L, seconds * 1_000L));
+        } catch (NumberFormatException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private static boolean isTransientStatus(int status) {
+        return status == 408 || status == 425 || status == 429 || status >= 500;
+    }
+
+    private static URI toUri(String uri) {
+        try {
+            URI parsed = new URI(uri);
+            if (parsed.getScheme() == null) {
+                return new File(uri).toURI();
+            }
+            return parsed;
+        } catch (URISyntaxException e) {
+            return new File(uri).toURI();
+        } catch (IllegalArgumentException e) {
+            throw new GradleException("Invalid repository URI " + uri, e);
+        }
+    }
+
+    private static boolean isLocalFile(URI uri) {
+        String scheme = uri.getScheme();
+        return scheme == null || "file".equalsIgnoreCase(scheme);
+    }
+
+    private static File toLocalFile(URI uri) {
+        if (uri.getScheme() == null) {
+            return new File(uri.getPath());
+        }
+        return new File(uri);
+    }
+
+    private static void copyAtomically(File source, File destination) throws IOException {
+        try (InputStream in = Files.newInputStream(source.toPath())) {
+            copyAtomically(in, destination);
+        }
+    }
+
+    private static void copyAtomically(InputStream input, File destination) throws IOException {
+        File parent = destination.getParentFile();
+        Files.createDirectories(parent.toPath());
+        File temporary = File.createTempFile(destination.getName(), ".tmp", parent);
+        try {
+            Files.copy(input, temporary.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            Files.move(temporary.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            Files.deleteIfExists(temporary.toPath());
+            throw e;
+        }
+    }
+
+    private static int intProperty(String name, int defaultValue) {
+        String value = System.getProperty(name);
+        if (value == null || value.isBlank()) {
+            String environmentName = name.toUpperCase(Locale.US).replace('.', '_');
+            value = System.getenv(environmentName);
+        }
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            return Math.max(1, Integer.parseInt(value.trim()));
+        } catch (NumberFormatException ignored) {
+            return defaultValue;
+        }
+    }
+
+    private enum DownloadResult {
+        DOWNLOADED,
+        NOT_FOUND
+    }
+
+    private static final class TransientDownloadException extends RuntimeException {
+        private TransientDownloadException(String message, Throwable cause) {
+            super(message, cause);
+        }
     }
 }

--- a/src/test/groovy/io/micronaut/build/pom/PomDownloaderTest.groovy
+++ b/src/test/groovy/io/micronaut/build/pom/PomDownloaderTest.groovy
@@ -1,0 +1,84 @@
+package io.micronaut.build.pom
+
+import com.sun.net.httpserver.HttpServer
+import org.gradle.api.GradleException
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
+
+class PomDownloaderTest extends Specification {
+    @TempDir
+    Path tmpDir
+
+    private HttpServer server
+
+    def cleanup() {
+        server?.stop(0)
+    }
+
+    def "retries rate limited POM downloads"() {
+        given:
+        def attempts = new AtomicInteger()
+        server = startServer { exchange ->
+            attempts.incrementAndGet()
+            if (attempts.get() == 1) {
+                exchange.responseHeaders.add('Retry-After', '0')
+                exchange.sendResponseHeaders(429, -1)
+            } else {
+                byte[] body = '<project/>'.getBytes(StandardCharsets.UTF_8)
+                exchange.sendResponseHeaders(200, body.length)
+                exchange.responseBody.withCloseable { it.write(body) }
+            }
+        }
+        def downloader = new PomDownloader([serverUrl()], tmpDir.toFile())
+
+        when:
+        def result = downloader.tryDownloadPom(new PomDependency(false, 'example', 'library', '1.0.0', 'compile'))
+
+        then:
+        result.present
+        result.get().text == '<project/>'
+        attempts.get() == 2
+    }
+
+    def "reports rate limiting as transient failure instead of missing dependency"() {
+        given:
+        server = startServer { exchange ->
+            exchange.responseHeaders.add('Retry-After', '0')
+            exchange.sendResponseHeaders(429, -1)
+        }
+        def downloader = new PomDownloader([serverUrl()], tmpDir.toFile())
+
+        when:
+        downloader.tryDownloadPom(new PomDependency(false, 'example', 'library', '1.0.0', 'compile'))
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains('Unable to download POM')
+    }
+
+    def "returns empty for missing POMs"() {
+        given:
+        server = startServer { exchange ->
+            exchange.sendResponseHeaders(404, -1)
+        }
+        def downloader = new PomDownloader([serverUrl()], tmpDir.toFile())
+
+        expect:
+        downloader.tryDownloadPom(new PomDependency(false, 'example', 'library', '1.0.0', 'compile')).empty
+    }
+
+    private HttpServer startServer(Closure handler) {
+        def httpServer = HttpServer.create(new InetSocketAddress(InetAddress.loopbackAddress, 0), 0)
+        httpServer.createContext('/') { exchange -> handler.call(exchange) }
+        httpServer.start()
+        httpServer
+    }
+
+    private String serverUrl() {
+        "http://${server.address.hostString}:${server.address.port}"
+    }
+}


### PR DESCRIPTION
## Summary
- distinguish missing POMs from transient repository failures in the BOM checker downloader
- retry transient HTTP failures such as 429/5xx with backoff and cap concurrent remote downloads
- add tests for retrying 429 responses, failing persistent throttling, and preserving 404 as missing

## Testing
- > Task :buildSrc:compileJava UP-TO-DATE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources NO-SOURCE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE
> Task :extractPluginRequests NO-SOURCE
> Task :generatePluginAdapters NO-SOURCE
> Task :generateVersions UP-TO-DATE
> Task :compileJava UP-TO-DATE
> Task :compileGroovy UP-TO-DATE
> Task :compileGroovyPlugins NO-SOURCE
> Task :pluginDescriptors UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :compileTestJava NO-SOURCE
> Task :compileTestGroovy UP-TO-DATE
> Task :processTestResources UP-TO-DATE
> Task :testClasses UP-TO-DATE
> Task :test UP-TO-DATE

BUILD SUCCESSFUL in 723ms
11 actionable tasks: 11 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.0.0/userguide/configuration_cache_enabling.html