### PR TITLE
Make NullAway opt-in for module projects

### DIFF
--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/PluginDefaultsFunctionalTest.groovy
@@ -198,6 +198,27 @@ class PluginDefaultsFunctionalTest extends AbstractFunctionalTest {
         }
     }
 
+    void "nullaway is opt-in for module projects"() {
+        given:
+        withSample("test-micronaut-module")
+
+        file("subproject1/build.gradle") << """
+            tasks.register("verifyNullAwayIsOptIn") {
+                doLast {
+                    assert project.extensions.findByName("micronautNullAway") == null
+                    assert project.configurations.findByName("errorprone") == null
+                    assert !project.pluginManager.hasPlugin("net.ltgt.errorprone")
+                }
+            }
+        """
+
+        when:
+        run ':subproject1:verifyNullAwayIsOptIn'
+
+        then:
+        noExceptionThrown()
+    }
+
     private void writeIncludedBuild(String name) {
         file("${name}/settings.gradle") << """
             pluginManagement {

--- a/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
+++ b/micronaut-gradle-plugins/src/functionalTest/groovy/io/micronaut/build/nullaway/MicronautNullAwayFunctionalTest.groovy
@@ -14,6 +14,7 @@ class MicronautNullAwayFunctionalTest extends AbstractFunctionalTest {
         }
 
         micronautBuild {
+            nullAway = true
             enableProcessing.set(false)
         }
 
@@ -46,6 +47,7 @@ class MicronautNullAwayFunctionalTest extends AbstractFunctionalTest {
         }
 
         micronautBuild {
+            nullAway = true
             enableProcessing.set(false)
         }
 
@@ -59,7 +61,7 @@ class MicronautNullAwayFunctionalTest extends AbstractFunctionalTest {
         }
     '''
 
-    void "nullaway plugin configures default checks and dependencies"() {
+    void "nullaway opt-in configures default checks and dependencies"() {
         given:
         settingsFile.text = "rootProject.name = 'nullaway-default'"
         gradlePropertiesFile.text = "projectVersion=1.0.0\ntitle=Demo"

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/build/MicronautBaseModulePlugin.groovy
@@ -26,12 +26,21 @@ class MicronautBaseModulePlugin implements Plugin<Project> {
         project.pluginManager.apply(MicronautBinaryCompatibilityPlugin)
         project.pluginManager.apply(SonatypeConfigurationPlugin)
         project.pluginManager.apply(MicronautModuleInfoPlugin)
-        project.pluginManager.apply(MicronautNullAwayPlugin)
+        configureNullAway(project)
         configureJUnit(project)
         assertSettingsPluginApplied(project)
         project.pluginManager.withPlugin("maven-publish") {
             PomCheckerUtils.registerPomChecker("checkPom", project, project.extensions.findByType(PublishingExtension)) {
                 it.suppressions.convention(project.extensions.getByType(MicronautBuildExtension).bomSuppressions)
+            }
+        }
+    }
+
+    private static void configureNullAway(Project project) {
+        MicronautBuildExtension micronautBuild = project.extensions.getByType(MicronautBuildExtension)
+        project.afterEvaluate {
+            if (micronautBuild.nullAway.get()) {
+                project.pluginManager.apply(MicronautNullAwayPlugin)
             }
         }
     }

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -100,13 +100,6 @@ public abstract class MicronautBuildExtension {
     public abstract Property<Boolean> getNullAway();
 
     /**
-     * Whether to enable NullAway checks for this project.
-     */
-    public Property<Boolean> getEnableNullAway() {
-        return getNullAway();
-    }
-
-    /**
      * Errors which should be suppressed when validating POMs.
      */
     @Nested

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautBuildExtension.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautBuildExtension.java
@@ -39,6 +39,7 @@ public abstract class MicronautBuildExtension {
         getEnforcedPlatform().convention(false);
         getEnableProcessing().convention(false);
         getEnableBom().convention(true);
+        getNullAway().convention(false);
     }
 
     public BuildEnvironment getEnvironment() {
@@ -92,6 +93,18 @@ public abstract class MicronautBuildExtension {
      * Whether to enable the Micronaut BOM for dependency management
      */
     public abstract Property<Boolean> getEnableBom();
+
+    /**
+     * Whether to enable NullAway checks for this project.
+     */
+    public abstract Property<Boolean> getNullAway();
+
+    /**
+     * Whether to enable NullAway checks for this project.
+     */
+    public Property<Boolean> getEnableNullAway() {
+        return getNullAway();
+    }
 
     /**
      * Errors which should be suppressed when validating POMs.


### PR DESCRIPTION
Add a nullAway/enableNullAway extension flag that defaults to false and only applies the Micronaut NullAway plugin when explicitly enabled. Update functional tests to opt in where NullAway behavior is expected and add coverage that module projects no longer apply NullAway by default.