### PR TITLE
ci: pin release workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -24,7 +27,7 @@ jobs:
       - name: Run pre-release
         env:
           MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
-        uses: micronaut-projects/github-actions/pre-release@master
+        uses: micronaut-projects/github-actions/pre-release@5f587657fc12601ab92d64d077f99a54c3cbdf78
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to Sonatype OSSRH
@@ -42,7 +45,7 @@ jobs:
           ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
       - name: Run post-release
         if: success()
-        uses: micronaut-projects/github-actions/post-release@master
+        uses: micronaut-projects/github-actions/post-release@5f587657fc12601ab92d64d077f99a54c3cbdf78
         env:
           MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
         with:


### PR DESCRIPTION
## Summary
- Pin the shared `micronaut-projects/github-actions` pre-release and post-release actions in the release workflow to reviewed commit `5f587657fc12601ab92d64d077f99a54c3cbdf78` instead of `master`.
- Add an explicit release-job `permissions:` block limited to `contents: write` and `issues: write`, matching the pinned actions' git/release and milestone operations without broadening token scope.

## Verification
- `git fetch origin 8.0.x && git merge --ff-only origin/8.0.x`
- `gh api repos/micronaut-projects/github-actions/commits/5f587657fc12601ab92d64d077f99a54c3cbdf78 --jq '{sha:.sha,message:.commit.message,date:.commit.committer.date}'`
- `git diff --check -- .github/workflows/release.yml`
- Targeted Python workflow check: no `pre-release@master`/`post-release@master`, no `id-token: write`, exactly two references to the reviewed SHA, and release-job permissions are `contents: write` plus `issues: write`.

## Release / project notes
- Type: `type: improvement`
- Target branch: `8.0.x`
- Release target: `v8.0.2` patch-line release workflow hardening
- Micronaut organization project selection from QA: `5.0.3 Release` (Project 153). Ambiguity note: `micronaut-build` is build/release infrastructure rather than a normal module dependency, so maintainers may retarget the Platform BOM release board if needed.

Closes DEV-1367

---
###### ✨ This message was AI-generated using gpt-5.5
