### PR TITLE
Support Scala sources in documentation snippets

### DIFF
--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/LanguageSnippetMacro.groovy
@@ -10,11 +10,7 @@ import org.asciidoctor.extension.BlockMacroProcessor
 public class LanguageSnippetMacro extends BlockMacroProcessor implements ValueAtAttributes {
     final Asciidoctor asciidoctor
 
-    private static final String LANG_JAVA = 'java'
-    private static final String LANG_GROOVY = 'groovy'
-    private static final String LANG_KOTLIN = 'kotlin'
-    private static final String LANG_PYTHON = 'python'
-    public static final List<String> LANGS = [LANG_JAVA, LANG_PYTHON, LANG_KOTLIN, LANG_GROOVY]
+    public static final List<String> LANGS = SnippetSourceResolver.languages
 
     LanguageSnippetMacro(String macroName, Map<String, Object> config, Asciidoctor asciidoctor) {
         super(macroName, config)
@@ -41,10 +37,11 @@ public class LanguageSnippetMacro extends BlockMacroProcessor implements ValueAt
 
         // If a specific target language is requested and it is one of the known code languages,
         // only render that language, and do NOT use the multi-language-sample selector class.
-        List<String> languagesToRender = LANGS
-        if (defaultLanguage && LANGS.contains(defaultLanguage)) {
-            languagesToRender = [defaultLanguage]
-        }
+        List<String> languagesToRender = SnippetSourceResolver.languagesToRender(
+                defaultLanguage,
+                valueAtAttributes('language', attributes),
+                valueAtAttributes('languages', attributes)
+        )
 
         String[] files = target.split(",")
         for (lang in languagesToRender) {

--- a/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/SnippetSourceResolver.java
+++ b/micronaut-gradle-plugins/src/main/groovy/io/micronaut/docs/SnippetSourceResolver.java
@@ -24,24 +24,82 @@ public final class SnippetSourceResolver {
     private static final String LANG_GROOVY = "groovy";
     private static final String LANG_KOTLIN = "kotlin";
     private static final String LANG_PYTHON = "python";
-    private static final List<String> LANGS = List.of(LANG_JAVA, LANG_PYTHON, LANG_KOTLIN, LANG_GROOVY);
+    private static final String LANG_SCALA = "scala";
+    private static final List<String> LANGS = List.of(LANG_JAVA, LANG_PYTHON, LANG_KOTLIN, LANG_GROOVY, LANG_SCALA);
     private static final String DEFAULT_KOTLIN_PROJECT = "test-suite-kotlin";
     private static final String DEFAULT_PYTHON_PROJECT = "test-suite-python";
     private static final String DEFAULT_JAVA_PROJECT = "test-suite";
     private static final String DEFAULT_GROOVY_PROJECT = "test-suite-groovy";
+    private static final String DEFAULT_SCALA_PROJECT = "test-suite-scala";
     private static final String ATTR_PROJECT = "project";
     private static final String ATTR_SOURCE = "source";
     private static final String ATTR_PROJECT_BASE = "project-base";
+    private static final String ATTR_LANGUAGE = "language";
+    private static final String ATTR_LANGUAGES = "languages";
     private static final Pattern SNIPPET_MACRO = Pattern.compile("(?m)^\\s*snippet::([^\\[]+)\\[([^\\]]*)]");
 
     private SnippetSourceResolver() {
     }
 
     public static List<String> languagesToRender(String defaultLanguage) {
-        if (defaultLanguage != null && LANGS.contains(defaultLanguage)) {
-            return List.of(defaultLanguage);
+        String language = normalize(defaultLanguage);
+        if (language != null && LANGS.contains(language)) {
+            return List.of(language);
         }
         return LANGS;
+    }
+
+    /**
+     * @return The supported snippet languages in their rendering order
+     */
+    public static List<String> getLanguages() {
+        return LANGS;
+    }
+
+    /**
+     * Resolve the language set for a snippet macro or source-tracking pass.
+     * An explicit {@code language} attribute takes precedence over
+     * {@code languages}, which takes precedence over the guide language.
+     *
+     * @param defaultLanguage The language of a language-specific guide
+     * @param attributes      The snippet attributes
+     * @return The languages to render
+     */
+    public static List<String> languagesToRender(String defaultLanguage, Map<String, Object> attributes) {
+        return languagesToRender(
+            defaultLanguage,
+            valueAtAttributes(ATTR_LANGUAGE, attributes),
+            valueAtAttributes(ATTR_LANGUAGES, attributes)
+        );
+    }
+
+    /**
+     * Resolve the language set for a snippet macro or source-tracking pass.
+     *
+     * @param defaultLanguage The language of a language-specific guide
+     * @param language        An optional single language override
+     * @param languages       An optional comma-separated language override
+     * @return The languages to render
+     */
+    public static List<String> languagesToRender(String defaultLanguage, String language, String languages) {
+        String explicitLanguage = normalize(language);
+        if (explicitLanguage != null) {
+            return LANGS.contains(explicitLanguage) ? List.of(explicitLanguage) : Collections.emptyList();
+        }
+
+        String explicitLanguages = normalize(languages);
+        if (explicitLanguages != null) {
+            Set<String> selected = new LinkedHashSet<>();
+            for (String candidate : explicitLanguages.split(",")) {
+                String normalized = normalize(candidate);
+                if (normalized != null && LANGS.contains(normalized)) {
+                    selected.add(normalized);
+                }
+            }
+            return List.copyOf(selected);
+        }
+
+        return languagesToRender(defaultLanguage);
     }
 
     public static Set<File> findSnippetSourceFiles(File sourceDir, File baseDir, String defaultLanguage) {
@@ -72,7 +130,7 @@ public final class SnippetSourceResolver {
         while (matcher.find()) {
             String target = matcher.group(1);
             Map<String, Object> attributes = parseAttributes(matcher.group(2));
-            for (String language : languagesToRender(defaultLanguage)) {
+            for (String language : languagesToRender(defaultLanguage, attributes)) {
                 for (String fileName : splitTargets(target)) {
                     File snippetFile = resolveSnippetFile(baseDir, language, fileName, attributes);
                     if (snippetFile.exists()) {
@@ -176,6 +234,9 @@ public final class SnippetSourceResolver {
         if (LANG_GROOVY.equals(language)) {
             return DEFAULT_GROOVY_PROJECT;
         }
+        if (LANG_SCALA.equals(language)) {
+            return DEFAULT_SCALA_PROJECT;
+        }
         return DEFAULT_JAVA_PROJECT;
     }
 
@@ -197,6 +258,14 @@ public final class SnippetSourceResolver {
     private static String valueAtAttributes(String name, Map<String, Object> attributes) {
         Object value = attributes.get(name);
         return value == null ? null : value.toString();
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        return normalized.isEmpty() ? null : normalized;
     }
 
     private static boolean isAsciiDoc(Path path) {

--- a/micronaut-gradle-plugins/src/test/groovy/io/micronaut/docs/LanguageSnippetMacroSpec.groovy
+++ b/micronaut-gradle-plugins/src/test/groovy/io/micronaut/docs/LanguageSnippetMacroSpec.groovy
@@ -1,6 +1,9 @@
 package io.micronaut.docs
 
 import org.asciidoctor.Asciidoctor
+import org.asciidoctor.Attributes
+import org.asciidoctor.Options
+import org.asciidoctor.SafeMode
 import org.asciidoctor.ast.StructuralNode
 import spock.lang.Specification
 
@@ -20,8 +23,11 @@ class LanguageSnippetMacroSpec extends Specification {
             StringBuilder content = new StringBuilder()
 
             String[] files = target.split(",")
-            // replicate macro languages
-            List<String> langs = ['java', 'groovy', 'kotlin']
+            List<String> langs = SnippetSourceResolver.languagesToRender(
+                    null,
+                    attributes.get('language') as String,
+                    attributes.get('languages') as String
+            )
             for (String lang : langs) {
                 if (title != null) {
                     content << ".$title\n\n"
@@ -99,6 +105,11 @@ ${includes.join("\n\n")}
             class Foo
             // end::a[]
         """.stripIndent()
+        File scalaFile = file("$baseProject/src/$sourceType/scala/$pkgPath/${className}.scala") << """
+            // tag::a[]
+            class Foo
+            // end::a[]
+        """.stripIndent()
 
         and: "a capturing macro instance"
         def macro = new CapturingLanguageSnippetMacro("language-snippet", [:], fakeAsciidoctor)
@@ -127,6 +138,49 @@ ${includes.join("\n\n")}
         and: "kotlin block and include"
         macro.capturedContent.contains("[source.multi-language-sample,kotlin,My Snippet]")
         macro.capturedContent.contains("include::${kotlinFile.absolutePath}[tag=a,indent=0]".toString())
+
+        and: "scala block and include"
+        macro.capturedContent.contains("[source.multi-language-sample,scala,My Snippet]")
+        macro.capturedContent.contains("include::${scalaFile.absolutePath}[tag=a,indent=0]".toString())
+    }
+
+    void "filters generated blocks by explicit language"() {
+        given:
+        Asciidoctor fakeAsciidoctor = [convert: { String c, Object o -> c }] as Asciidoctor
+        String baseProject = "build/test-snippets-filtered"
+        File scalaFile = file("$baseProject/src/test/scala/example/Foo.scala") << "class Foo"
+        file("$baseProject/src/test/java/example/Foo.java") << "class Foo {}"
+        def macro = new CapturingLanguageSnippetMacro("language-snippet", [:], fakeAsciidoctor)
+
+        when:
+        macro.process(null, "example.Foo", [project: baseProject, language: "scala"])
+
+        then:
+        macro.capturedContent.contains("[source.multi-language-sample,scala,null]")
+        macro.capturedContent.contains("include::${scalaFile.absolutePath}[]".toString())
+        !macro.capturedContent.contains("source.multi-language-sample,java")
+    }
+
+    void "live asciidoctor macro honors explicit language"() {
+        given:
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create()
+        asciidoctor.javaExtensionRegistry().blockMacro(new LanguageSnippetMacro("snippet", [:], asciidoctor))
+        File scalaFile = file("build/live-macro-snippets/test-suite-scala/src/test/scala/example/Foo.scala") << "class Foo"
+        file("build/live-macro-snippets/test-suite/src/test/java/example/Foo.java") << "class Foo {}"
+        Options options = Options.builder()
+                .attributes(Attributes.builder().attribute("sourcedir", new File("build/live-macro-snippets").absolutePath).build())
+                .safe(SafeMode.UNSAFE)
+                .build()
+
+        when:
+        String rendered = asciidoctor.convert('snippet::example.Foo[language="scala"]', options)
+
+        then:
+        rendered.contains("class Foo")
+        !rendered.contains("source.multi-language-sample,java")
+
+        cleanup:
+        asciidoctor.shutdown()
     }
 
     private static File file(String path) {

--- a/micronaut-gradle-plugins/src/test/groovy/io/micronaut/docs/SnippetSourceResolverSpec.groovy
+++ b/micronaut-gradle-plugins/src/test/groovy/io/micronaut/docs/SnippetSourceResolverSpec.groovy
@@ -17,6 +17,7 @@ class SnippetSourceResolverSpec extends Specification {
         def groovyFile = file("test-suite-groovy/src/test/groovy/example/Foo.groovy")
         def kotlinFile = file("test-suite-kotlin/src/test/kotlin/example/Foo.kt")
         def pythonFile = file("test-suite-python/src/test/python/example/Foo.py")
+        def scalaFile = file("test-suite-scala/src/test/scala/example/Foo.scala")
         def secondJavaFile = file("test-suite/src/test/java/example/Bar.java")
 
         expect:
@@ -24,7 +25,7 @@ class SnippetSourceResolverSpec extends Specification {
                 testDirectory.resolve("src/main/docs").toFile(),
                 testDirectory.toFile(),
                 ""
-        ) == [javaFile, secondJavaFile, pythonFile, kotlinFile, groovyFile] as Set
+        ) == [javaFile, secondJavaFile, pythonFile, kotlinFile, groovyFile, scalaFile] as Set
     }
 
     void "finds snippet source files for language specific guide"() {
@@ -41,6 +42,24 @@ class SnippetSourceResolverSpec extends Specification {
         ) == [kotlinFile] as Set
     }
 
+    void "honors explicit language filters"() {
+        given:
+        file("src/main/docs/guide/index.adoc") << """
+snippet::example.Foo[language=scala]
+snippet::example.Bar[languages="java,scala"]
+""".stripIndent()
+        def scalaFile = file("test-suite-scala/src/test/scala/example/Foo.scala")
+        def javaFile = file("test-suite/src/test/java/example/Bar.java")
+        def secondScalaFile = file("test-suite-scala/src/test/scala/example/Bar.scala")
+
+        expect:
+        SnippetSourceResolver.findSnippetSourceFiles(
+                testDirectory.resolve("src/main/docs").toFile(),
+                testDirectory.toFile(),
+                "kotlin"
+        ) == [scalaFile, javaFile, secondScalaFile] as Set
+    }
+
     void "honors snippet project source project base and python package rules"() {
         given:
         file("src/main/docs/guide/index.adoc") << """
@@ -52,13 +71,14 @@ snippet::io.micronaut.Sample[project-base=base]
         def basePythonFile = file("base-python/src/test/python/micronaut/Sample.py")
         def baseKotlinFile = file("base-kotlin/src/test/kotlin/io/micronaut/Sample.kt")
         def baseGroovyFile = file("base-groovy/src/test/groovy/io/micronaut/Sample.groovy")
+        def baseScalaFile = file("base-scala/src/test/scala/io/micronaut/Sample.scala")
 
         expect:
         SnippetSourceResolver.findSnippetSourceFiles(
                 testDirectory.resolve("src/main/docs").toFile(),
                 testDirectory.toFile(),
                 ""
-        ) == [customJavaFile, baseJavaFile, basePythonFile, baseKotlinFile, baseGroovyFile] as Set
+        ) == [customJavaFile, baseJavaFile, basePythonFile, baseKotlinFile, baseGroovyFile, baseScalaFile] as Set
     }
 
     private File file(String path) {


### PR DESCRIPTION
## Summary

- Discover Scala documentation sources from `test-suite-scala`.
- Support Scala as a snippet language and use `test-suite-scala` as its default project.
- Add `language` and `languages` filtering with focused resolver and macro tests.

## Rationale

The Scala documentation follow-up in [micronaut-core PR #12981](https://github.com/micronaut-projects/micronaut-core/pull/12981) needs the documentation tooling to discover source-backed Scala examples and render selected languages. This prerequisite keeps that behavior in micronaut-build rather than embedding untested Scala code in AsciiDoc.

## Related PRs

- [micronaut-core SPI: #12695](https://github.com/micronaut-projects/micronaut-core/pull/12695)
- [micronaut-scala implementation: #2](https://github.com/micronaut-projects/micronaut-scala/pull/2)
- [micronaut-core documentation follow-up: #12981](https://github.com/micronaut-projects/micronaut-core/pull/12981)

## Verification

- `./gradlew :micronaut-gradle-plugins:test --tests io.micronaut.docs.SnippetSourceResolverSpec --tests io.micronaut.docs.LanguageSnippetMacroSpec --no-daemon --console=plain` passed.