### PR TITLE
Write to the remote build cache by default only from trusted pushes

### DIFF
--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautDevelocityPlugin.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/MicronautDevelocityPlugin.java
@@ -91,7 +91,9 @@ public class MicronautDevelocityPlugin implements Plugin<Settings> {
             BuildCacheConfiguration buildCache = settings.getBuildCache();
             boolean localEnabled = micronautBuildSettingsExtension.getUseLocalCache().get();
             boolean remoteEnabled = micronautBuildSettingsExtension.getUseRemoteCache().get();
-            boolean push = MicronautBuildSettingsExtension.booleanProvider(providers, "cachePush", isCI).get();
+            // Only CI builds of pushes to release or default branches write to the remote cache by default;
+            // the cachePush property overrides this
+            boolean push = MicronautBuildSettingsExtension.booleanProvider(providers, "cachePush", isCI && ProviderUtils.isTrustedGitHubPush(providers)).get();
             if (isCI) {
                 System.out.println("Build cache     enabled     push");
                 System.out.println("    Local        " + (localEnabled ? "   Y   " : "   N   ") + "     N/A");
@@ -108,12 +110,8 @@ public class MicronautDevelocityPlugin implements Plugin<Settings> {
         buildCache.remote(config.getBuildCache(), remote -> {
             remote.setEnabled(true);
             if (push) {
-                String accessKey = providers.environmentVariable("GRADLE_ENTERPRISE_ACCESS_KEY")
-                    .orElse(providers.environmentVariable("DEVELOCITY_ACCESS_KEY"))
-                    // this one below is weird but for backward compatibility
-                    .orElse(providers.systemProperty("GRADLE_ENTERPRISE_ACCESS_KEY"))
-                    .getOrNull();
-                if (accessKey != null && !accessKey.isEmpty()) {
+                String accessKey = ProviderUtils.findDevelocityAccessKey(providers);
+                if (accessKey != null) {
                     remote.setPush(true);
                 } else {
                     System.err.println("WARNING: Access key missing for remote build cache, cannot configure push!");

--- a/micronaut-gradle-plugins/src/main/java/io/micronaut/build/utils/ProviderUtils.java
+++ b/micronaut-gradle-plugins/src/main/java/io/micronaut/build/utils/ProviderUtils.java
@@ -20,18 +20,74 @@ import org.gradle.api.provider.ProviderFactory;
 
 import java.io.File;
 import java.util.Properties;
+import java.util.function.Function;
+import java.util.regex.Pattern;
 
 public class ProviderUtils {
+    private static final Pattern TRUSTED_BRANCH_REF = Pattern.compile("refs/heads/(master|main|[0-9]+\\.[0-9]+\\.x)");
+
     public static boolean guessCI(ProviderFactory providers) {
-        return providers
-                .environmentVariable("CI")
-                .flatMap(s -> // Not all workflows may have the enterprise key set
-                        providers.environmentVariable("GRADLE_ENTERPRISE_ACCESS_KEY")
-                                .map(env -> true)
-                                .orElse(false)
-                )
-                .orElse(false)
-                .get();
+        return guessCI(name -> providers.environmentVariable(name).getOrNull());
+    }
+
+    static boolean guessCI(Function<String, String> environment) {
+        // Not all workflows have a Develocity access key set. setup-gradle exports short-lived tokens
+        // under both names; workflows that pass the key themselves use DEVELOCITY_ACCESS_KEY.
+        return environment.apply("CI") != null
+            && (isNotBlank(environment.apply("DEVELOCITY_ACCESS_KEY"))
+            || isNotBlank(environment.apply("GRADLE_ENTERPRISE_ACCESS_KEY")));
+    }
+
+    /**
+     * Whether this is a GitHub Actions build of a push to a release or default branch. Only such builds
+     * write to the remote build cache by default: pull requests, merge queues, {@code workflow_run},
+     * scheduled and manually dispatched builds may run code that has not been merged.
+     *
+     * @param providers the provider factory
+     * @return true for a {@code push} event to {@code master}, {@code main} or an {@code x.y.x} branch
+     */
+    public static boolean isTrustedGitHubPush(ProviderFactory providers) {
+        return isTrustedGitHubPush(name -> providers.environmentVariable(name).getOrNull());
+    }
+
+    static boolean isTrustedGitHubPush(Function<String, String> environment) {
+        String ref = environment.apply("GITHUB_REF");
+        return "push".equals(environment.apply("GITHUB_EVENT_NAME"))
+            && ref != null
+            && TRUSTED_BRANCH_REF.matcher(ref).matches();
+    }
+
+    /**
+     * Finds the Develocity access key, ignoring blank values so that an empty variable does not hide a
+     * configured one.
+     *
+     * @param providers the provider factory
+     * @return the access key, or null if none is configured
+     */
+    public static String findDevelocityAccessKey(ProviderFactory providers) {
+        return findDevelocityAccessKey(
+            name -> providers.environmentVariable(name).getOrNull(),
+            name -> providers.systemProperty(name).getOrNull()
+        );
+    }
+
+    static String findDevelocityAccessKey(Function<String, String> environment, Function<String, String> systemProperties) {
+        String[] candidates = {
+            environment.apply("DEVELOCITY_ACCESS_KEY"),
+            environment.apply("GRADLE_ENTERPRISE_ACCESS_KEY"),
+            // kept for backward compatibility
+            systemProperties.apply("GRADLE_ENTERPRISE_ACCESS_KEY")
+        };
+        for (String candidate : candidates) {
+            if (isNotBlank(candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isNotBlank(String value) {
+        return value != null && !value.isBlank();
     }
 
     public static String envOrSystemProperty(ProviderFactory providers, String envName, String propertyName, String defaultValue) {

--- a/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/utils/ProviderUtilsSpec.groovy
+++ b/micronaut-gradle-plugins/src/test/groovy/io/micronaut/build/utils/ProviderUtilsSpec.groovy
@@ -1,0 +1,53 @@
+package io.micronaut.build.utils
+
+import spock.lang.Specification
+
+class ProviderUtilsSpec extends Specification {
+
+    void "detects CI from #description"(Map<String, String> environment, boolean expected, String description) {
+        expect:
+        ProviderUtils.guessCI(environment::get) == expected
+
+        where:
+        environment                                                    | expected | description
+        [CI: 'true', GRADLE_ENTERPRISE_ACCESS_KEY: 'ge.micronaut.io=x'] | true     | 'the Gradle Enterprise access key'
+        [CI: 'true', DEVELOCITY_ACCESS_KEY: 'ge.micronaut.io=x']        | true     | 'the Develocity access key'
+        [CI: 'true', DEVELOCITY_ACCESS_KEY: '']                        | false    | 'an empty access key, as for fork pull requests'
+        [CI: 'true']                                                   | false    | 'no access key'
+        [DEVELOCITY_ACCESS_KEY: 'ge.micronaut.io=x']                   | false    | 'an access key outside CI'
+    }
+
+    void "writes to the build cache by default only for pushes to trusted branches: #eventName #ref"(String eventName, String ref, boolean expected) {
+        expect:
+        ProviderUtils.isTrustedGitHubPush([GITHUB_EVENT_NAME: eventName, GITHUB_REF: ref]::get) == expected
+
+        where:
+        eventName             | ref                          | expected
+        'push'                | 'refs/heads/5.2.x'           | true
+        'push'                | 'refs/heads/master'          | true
+        'push'                | 'refs/heads/main'            | true
+        'push'                | 'refs/heads/feature/5.2.x'   | false
+        'push'                | 'refs/heads/claude/fix'      | false
+        'push'                | 'refs/tags/v5.2.0'           | false
+        'pull_request'        | 'refs/pull/1/merge'          | false
+        'pull_request_target' | 'refs/heads/5.2.x'           | false
+        'merge_group'         | 'refs/heads/gh-readonly-queue/5.2.x/pr-1' | false
+        'workflow_run'        | 'refs/heads/5.2.x'           | false
+        'schedule'            | 'refs/heads/5.2.x'           | false
+        'workflow_dispatch'   | 'refs/heads/5.2.x'           | false
+        null                  | null                         | false
+    }
+
+    void "finds the access key from #description"(Map<String, String> environment, Map<String, String> systemProperties, String expected, String description) {
+        expect:
+        ProviderUtils.findDevelocityAccessKey(environment::get, systemProperties::get) == expected
+
+        where:
+        environment                                                                      | systemProperties                          | expected                | description
+        [DEVELOCITY_ACCESS_KEY: 'ge.micronaut.io=new']                                    | [:]                                       | 'ge.micronaut.io=new'   | 'the Develocity variable'
+        [GRADLE_ENTERPRISE_ACCESS_KEY: 'ge.micronaut.io=old']                             | [:]                                       | 'ge.micronaut.io=old'   | 'the Gradle Enterprise variable'
+        [GRADLE_ENTERPRISE_ACCESS_KEY: '', DEVELOCITY_ACCESS_KEY: 'ge.micronaut.io=new']   | [:]                                       | 'ge.micronaut.io=new'   | 'the Develocity variable when the legacy one is blank'
+        [DEVELOCITY_ACCESS_KEY: ' ']                                                      | [GRADLE_ENTERPRISE_ACCESS_KEY: 'ge.micronaut.io=prop'] | 'ge.micronaut.io=prop' | 'the legacy system property'
+        [DEVELOCITY_ACCESS_KEY: '']                                                       | [:]                                       | null                    | 'nothing when all are blank'
+    }
+}


### PR DESCRIPTION
The Develocity settings plugin decides whether a build writes to the remote build cache from `cachePush`, defaulting to "is this CI". Two problems:

1. **CI detection only recognises `GRADLE_ENTERPRISE_ACCESS_KEY`.** The synced Micronaut workflows export `DEVELOCITY_ACCESS_KEY`, so `guessCI` returns false and nothing is pushed. In micronaut-core Java CI on 2026-09-11, `setup.sh` executed all 387 tasks and the main build pulled 46 of 849 from cache.
2. **Fixing detection alone would let untrusted builds push.** With `cachePush` defaulting to `isCI`, every CI build that holds a key would write to the cache, including pull requests, merge queues and `workflow_run` builds that run unmerged code. This already applies to any workflow using `gradle/actions/setup-gradle` with a key, which exports the token under both variable names.

## Changes
- **CI detection:** `ProviderUtils.guessCI` accepts `DEVELOCITY_ACCESS_KEY` as well as `GRADLE_ENTERPRISE_ACCESS_KEY`, and treats blank values as absent. A fork pull request, whose secret expands to an empty string, is no longer CI.
- **Default push rule:** `cachePush` now defaults to `isCI && ProviderUtils.isTrustedGitHubPush(...)`, which is true only for a `push` event to `refs/heads/master`, `main` or `x.y.x`. An explicit `cachePush` property still overrides it.
- **Key lookup:** `ProviderUtils.findDevelocityAccessKey` is used by the push check. It prefers `DEVELOCITY_ACCESS_KEY`, then `GRADLE_ENTERPRISE_ACCESS_KEY`, then the legacy system property, and skips blank values. Before, an empty `GRADLE_ENTERPRISE_ACCESS_KEY` hid a valid `DEVELOCITY_ACCESS_KEY`, and push stayed off.
- **Implementation:** the environment is still read through `ProviderFactory`, so configuration cache inputs are tracked. The logic sits in package-private functions for testing.

## Behaviour changes
- **Builds that no longer push by default:** scheduled, manually dispatched, `release`, `merge_group`, `workflow_run` and non-GitHub CI builds. A workflow that wants them to write sets `ORG_GRADLE_PROJECT_cachePush=true`.
- **Build scans:** they still publish for any CI build (`isCI || authenticated`), which now also covers builds with only `DEVELOCITY_ACCESS_KEY`.

## Tests
`ProviderUtilsSpec`, 23 cases: CI detection, including a blank key and a key outside CI; the trusted push classification for push, feature branch, tag, `pull_request`, `pull_request_target`, `merge_group`, `workflow_run`, `schedule` and `workflow_dispatch`; and key lookup precedence with blank values. `./gradlew :micronaut-gradle-plugins:test --tests io.micronaut.build.utils.ProviderUtilsSpec` passes on JDK 25.

## Related
- micronaut-projects/micronaut-project-template#792: native tests after Java CI, `cachePush` set explicitly, short-lived token in Java CI.
- micronaut-projects/github-actions#58: GraalVM composite actions on setup-gradle v6 with the same trusted push rule.

The design was reviewed with Codex (gpt-6-astra). The trusted-push default, rather than "not a pull request", and the blank-key precedence fix both came from that review.

## Sources
- [Gradle User Manual: Build Cache](https://docs.gradle.org/current/userguide/build_cache.html) says CI "populates it from clean builds while developers only load from it".
- [Develocity Gradle plugin user manual](https://docs.develocity.ai/gradle-plugin/current/) covers the `DEVELOCITY_ACCESS_KEY` format and short-lived access tokens.
- [gradle/actions setup-gradle: managing Develocity access keys](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#managing-develocity-access-keys).
- [setup-gradle token export at the pinned SHA](https://github.com/gradle/actions/blob/9c971963bec38e04b3d30dcc455b5382be2fdbfb/sources/src/develocity/short-lived-token.ts) exports both `DEVELOCITY_ACCESS_KEY` and `GRADLE_ENTERPRISE_ACCESS_KEY`.
- [spring-io/develocity-conventions](https://github.com/spring-io/develocity-conventions/blob/main/README.md): "Credentials must not be configured in environments where pull requests are built."
- [GitHub: events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows) covers the `merge_group`, `workflow_run` and `pull_request_target` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
